### PR TITLE
refactor: misc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
       - develop
+env:
+  FC: ifort
 jobs:
   test:
     name: Test
@@ -16,74 +18,67 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        path: [ absolute, relative, tilde, default ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install ifort
-        uses: ./
-      - name: Test ifort
+      - name: Set bin path
         if: runner.os != 'Windows'
         run: |
-          ./test/test.sh /opt/intel/oneapi
-      - name: Test ifort (Windows)
+          if [ "${{ matrix.path }}" == "absolute" ]; then
+            bindir="$HOME/.local/bin"
+          elif [ "${{ matrix.path }}" == "relative" ]; then
+            bindir="bin"
+          elif [ "${{ matrix.path }}" == "tilde" ]; then
+            bindir="~/.local/bin"
+          else
+            # action's default location
+            bindir="~/.local/bin/ifort"
+          fi
+
+          echo "TEST_BINDIR=$bindir" >> $GITHUB_ENV
+      - name: Set bin path (Windows)
         if: runner.os == 'Windows'
+        shell: pwsh
         run: |
-          ./test/test.ps1 "C:\Program Files (x86)\Intel\oneAPI"
-  test_compile_modflow:
-    name: Test compile modflow6
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        env: [ pip, miniconda, micromamba ]
-    defaults:
-      run:
-        shell:
-          bash -l {0}
-    steps:
-      - name: Checkout action
-        uses: actions/checkout@v3
-      - name: Checkout modflow6
-        uses: actions/checkout@v3
-        with:
-          repository: MODFLOW-USGS/modflow6
-          path: modflow6
+          if ("${{ matrix.path }}" -eq "absolute") {
+            # $bindir = "C:\Users\runneradmin\.local\bin"
+            $bindir = "C:\Program Files (x86)\Intel\oneAPI"
+          } elseif ("${{ matrix.path }}" -eq "relative") {
+            $bindir = "bin"
+          } elseif ("${{ matrix.path }}" -eq "tilde") {
+            $bindir = "~/.local/bin"
+          } else {
+            # actions's default location
+            $bindir = "~/.local/bin/ifort"
+          }
+
+          echo "TEST_BINDIR=$bindir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Install ifort
+        if: matrix.path != 'default'
         uses: ./
-      - name: Setup Python
-        if: matrix.env == 'pip'
-        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
-      - name: Install Python dependencies
-        if: matrix.env == 'pip'
-        run: |
-          pip3 install -r test/requirements.txt
-      - name: Install miniconda environment
-        if: matrix.env == 'miniconda'
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          environment-file: modflow6/environment.yml
-      - name: Install micromamba environment
-        if: matrix.env == 'micromamba'
-        uses: mamba-org/provision-with-micromamba@main
-        with:
-          environment-file: modflow6/environment.yml
-          cache-downloads: true
-          cache-env: true
-      - name: Build modflow6
+          path: ${{ env.TEST_BINDIR }}
+      - name: Install ifort
+        if: matrix.path == 'default'
+        uses: ./
+      - name: Test ifort (Linux & Mac)
         if: runner.os != 'Windows'
-        working-directory: modflow6
         run: |
-          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
-          meson compile -v -C builddir
-          meson install -C builddir
-      - name: Build modflow6 (Windows)
+          ./test/test.sh ${{ env.TEST_BINDIR }}
+      # TODO: reenable if ifort configuration for bash resolved on Windows
+      # - name: Test ifort (Windows bash)
+      #   if: runner.os == 'Windows'
+      #   shell: bash
+      #   run: |
+      #     ./test/test.sh "${{ env.TEST_BINDIR }}"
+      - name: Test ifort (Windows pwsh)
         if: runner.os == 'Windows'
-        working-directory: modflow6
+        shell: pwsh
         run: |
-          export PATH="/C/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.33.31629/bin/Hostx64/x64":$PATH
-          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
-          meson compile -v -C builddir
-          meson install -C builddir
+          ./test/test.ps1 "${{ env.TEST_BINDIR }}"
+      - name: Test ifort (Windows cmd)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          call "./test/test.bat"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,92 @@
+name: MODFLOW 6 integration testing
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  schedule:
+    - cron: '0 6 * * *' # run at 6 AM UTC every day
+jobs:
+  test_build_modflow:
+    name: Test build modflow6
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        env: [ pip, miniconda, micromamba ]
+    defaults:
+      run:
+        shell:
+          # necessary for miniconda and micromamba
+          # https://github.com/mamba-org/provision-with-micromamba#important
+          bash -l {0}
+    steps:
+      - name: Checkout action
+        uses: actions/checkout@v3
+      - name: Checkout modflow6
+        uses: actions/checkout@v3
+        with:
+          repository: MODFLOW-USGS/modflow6
+          path: modflow6
+      - name: Setup Python
+        if: matrix.env == 'pip'
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Install Python dependencies
+        if: matrix.env == 'pip'
+        run: |
+          pip3 install -r test/requirements.txt
+      - name: Install miniconda environment
+        if: matrix.env == 'miniconda'
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          environment-file: modflow6/environment.yml
+      - name: Install micromamba environment
+        if: matrix.env == 'micromamba'
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: modflow6/environment.yml
+          cache-downloads: true
+          cache-env: true
+      - name: Install ifort
+        uses: ./
+        with:
+          path: ${{ runner.os != 'Windows' && 'bin' || 'C:\Program Files (x86)\Intel\oneAPI' }}
+      - name: Build modflow6 (Linux & Mac)
+        if: runner.os != 'Windows'
+        working-directory: modflow6
+        run: |
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          meson compile -v -C builddir
+          meson install -C builddir
+      - name: Add micromamba bindir to path (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $mamba_bin = "C:\Users\runneradmin\micromamba-root\envs\modflow6\Scripts"
+          if (Test-Path $mamba_bin) {
+            # ifort/micromamba interfere with one another's PATH settings
+            echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          }
+      - name: Build modflow6 (Windows pwsh)
+        if: runner.os == 'Windows'
+        working-directory: modflow6
+        shell: pwsh
+        run: |
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          meson compile -v -C builddir
+          meson install -C builddir
+      - name: Build modflow6 (Windows cmd)
+        if: runner.os == 'Windows'
+        working-directory: modflow6
+        shell: cmd /C call {0}
+        run: |
+          meson setup builddir -Ddebug=false --prefix=%CD% --libdir=bin
+          meson compile -v -C builddir
+          meson install -C builddir

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Contributing](#contributing)
+  - [Issues and features](#issues-and-features)
+  - [Pull requests](#pull-requests)
+  - [Commit messages](#commit-messages)
+    - [Commit Message Format](#commit-message-format)
+      - [Type](#type)
+      - [Subject](#subject)
+      - [Body](#body)
+      - [Footer](#footer)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Contributing
 
 Contributions to this repository are welcome. To make a contribution we ask that you follow a few guidelines.
@@ -16,9 +32,11 @@ If `develop` changes while your work is still in progress, please rebase and fix
 
 ## Commit messages
 
-To keep the repository's commit history consistent, commit messages must conform to the following formatting conventions.
+Commit messages must conform to the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. This makes the commit history easier to follow and allows an automatically generated changelog.
 
-Each commit message consists of a **header**, a **body** and a **footer**.  The header includes a **type**, a **scope** and a **subject**:
+### Commit Message Format
+
+Each commit message consists of a **header**, a **body** and a **footer**. The **header** is mandatory, while **body** and **footer** are optional.
 
 ```
 <type>(<scope>): <subject>
@@ -28,11 +46,13 @@ Each commit message consists of a **header**, a **body** and a **footer**.  The 
 <footer>
 ```
 
-The **header** is mandatory and its **scope** is optional. The message **body** and **footer** are also optional.
+Note the header's format, which includes a **type**, a **scope** and a **subject**. Header **type** and **subject** are mandatory while header **scope** is optional.
 
-Please keep lines under 100 characters.
+No line of the commit message may be longer 100 characters! This makes messages easier to read on GitHub as well as in various `git` tools.
 
-### Type
+If a commit closes an issue, the footer should contain a [closing reference](https://help.github.com/articles/closing-issues-via-commit-messages/).
+
+#### Type
 
 Must be one of the following:
 
@@ -46,20 +66,7 @@ Must be one of the following:
 * **test**: Adding missing tests or correcting existing tests
 * **revert**: Reverts a previous commit
 
-### Scope
-The scope should be the name of the FloPy module/class affected (as perceived by the person reading the changelog generated from commit messages.
-
-There are currently a few exceptions to the "use module/class name" rule:
-
-* **release**: used when updating files prior to a release
-* **releasenotes**: used for updating the release notes
-* **readme**: used for updating the release notes in README.md
-* **changelog**: used for updating the release notes in CHANGELOG.md
-* none/empty string: useful for `style`, `test` and `refactor` changes that are done across all
-  packages (e.g. `style: add missing semicolons`) and for docs changes that are not related to a
-  specific package (e.g. `docs: fix typo in tutorial`).
-
-### Subject
+#### Subject
 
 The subject contains a succinct description of the change:
 
@@ -67,12 +74,12 @@ The subject contains a succinct description of the change:
 * don't capitalize the first letter
 * do not include a dot (.) at the end
 
-### Body
+#### Body
 
 Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
 The body should include the motivation for the change and contrast this with previous behavior.
 
-### Footer
+#### Footer
 
 The footer should contain any information about **Breaking Changes** and is also the place to reference GitHub issues that this commit **Closes**.
 

--- a/README.md
+++ b/README.md
@@ -2,31 +2,30 @@
 
 [![CI](https://github.com/modflowpy/install-intelfortran-action/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/modflowpy/install-intelfortran-action/actions/workflows/ci.yml)
 
-An action to install the [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran compiler.
+An action to install the [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran classic compiler via the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
-- [Install location](#install-location)
-  - [Linux & Mac](#linux--mac)
-  - [Windows](#windows)
-- [Usage](#usage)
-- [Attribution](#attribution)
+- [Overview](#overview)
+- [Example](#example)
+- [Inputs](#inputs)
+  - [`path`](#path)
+- [Environment variables](#environment-variables)
+- [Windows caveats](#windows-caveats)
+  - [Supported shells](#supported-shells)
+  - [Install location](#install-location)
+  - [Micromamba `Scripts`](#micromamba-scripts)
+- [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-## Install location
+## Overview
 
-### Linux & Mac
+This action installs the [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran compiler. It does this by downloading and running the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy) offline installer, selecting only the `ifort-compiler` component. After installing the compiler distribution, the action configures [environment variables](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup.html) necessary to invoke `ifort` from subsequent workflow steps.
 
-On Linux and MacOS, the compiler is installed to `/opt/intel/oneapi`.
-
-### Windows
-
-On Windows the install location is `C:\Program Files (x86)\Intel\oneAPI`.
-
-## Usage
+## Example
 
 To use this action, add a step like the following to your workflow:
 
@@ -35,23 +34,75 @@ To use this action, add a step like the following to your workflow:
   uses: modflowpy/install-intelfortran-action@v1
 ```
 
-The action will configure [environment variables](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup.html) necessary to invoke `ifort` from subsequent workflow steps. GitHub Actions does not preserve environment variables between steps by default &mdash; this action persists them by [appending to the `GITHUB_ENV` environment file](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable).
+## Inputs
 
-**Note:** Python, Conda or Micromamba environments can modify the system path on Windows runners and cause the default `link.exe` (located at `C:\Program Files\Git\usr\bin`) to be found instead of the [MSVC linker](https://docs.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170) required by `ifort`. To prevent this, prepend the MSVC linker's bin directory to the path. For instance, from `bash`:
+- `path`
 
-```shell
-export PATH="/C/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.33.31629/bin/Hostx64/x64":$PATH
+### `path`
+
+The `path` input is the location to install executables. The path may be absolute, relative to the workflow's working directory, or may use `~`-expansion. The path is resolved and stored in the `INTEL_HPCKIT_INSTALL_PATH` environment variable, which is then available to subsequent workflow steps.
+
+The default install location on Linux and Mac is `~/.local/bin/ifort`. The *only* install location currently supported on Windows is `C:\Program Files (x86)\Intel\oneAPI` (see [Caveats](#caveats) section below).
+
+<!-- ### `version`
+
+The `version` input configures the oneAPI toolkit version to install, defaulting to the latest (currently `2022.3`). 
+
+**Note:** Intel's website does not maintain a programmatically accessible registry of available versions. Moreover, toolkit versioning is distinct from compiler versioning (see [this page] for a mapping between toolkit and compiler versions). For these reasons a list of permitted version numbers are hard-coded into this action. If a new version has been released and this action has not been updated to support it, please feel free to [file an issue](https://github.com/modflowpy/install-intelfortran-action/issues/new).
+
+### `components`
+
+The `components` input allows specifying extra components to install from the HPC kit. -->
+
+## Environment variables
+
+The action runs oneAPI configuration scripts (e.g. `setvars.sh`), which set a number of environment variables, the names of which share substring `ONEAPI`.
+
+A few additional variables are also set:
+
+- `INTEL_HPCKIT_INSTALL_PATH` points to the top-level install path
+- `INTEL_HPCKIT_INSTALLER_URL` is the URL of the installer used
+- `INTEL_HPCKIT_COMPONENT` is the compiler component installed (e.g. `intel.oneapi.win.ifort-compiler` for Windows)
+- `INTEL_COMPILER_BIN_PATH` is the location of compiler executables (this is equivalent to `$HPCKIT_INSTALL_PATH/compilers/latest/<mac, linux, or windows>/bin/intel64`, substituting the proper OS)
+- `INTEL_HPCKIT_VERSION` is the oneAPI HPC toolkit version number used (currently `2022.3`)
+
+**Note:** GitHub Actions does not preserve environment variables between steps by default &mdash; this action persists them via the [`GITHUB_ENV` environment file](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable).
+
+## Windows caveats
+
+There are a few things to be aware of when using this action, in particular on Windows runners.
+
+### Supported shells
+
+While this action supports all three operating systems, it is currently unable to configure the compiler environment for the `bash` shell on Windows. Windows runners must invoke it from a step using the `cmd` or `pwsh` shell.
+
+### Install location
+
+While the HPC toolkit's install location can be selected freely on Linux and Mac, on Windows there is an unresolved issue causing bundled environment configuration scripts [to fail](https://github.com/w-bonelli/install-intelfortran-action/actions/runs/3298296907/jobs/5440222932#step:5:120) when the toolkit is installed to locations other than the default `C:\Program Files (x86)\Intel\oneAPI`. Different values for the `path` input are currently ignored for Windows and this location is configured automatically.
+
+<!-- The Intel oneAPI HPC Toolkit installer defaults to different install locations on Unix and Windows if a path is not explicitly provided with the `--install-dir` option:
+
+- Linux/Mac: `/opt/intel/oneapi`
+- Windows: `C:\Program Files (x86)\Intel\oneAPI`
+
+**This action overrides these.** The action's default install location, `~/.local/bin/ifort`, is the same on all three platforms. -->
+
+### Micromamba `Scripts`
+
+This action and the `mamba-org/provision-with-micromamba` action can stomp on each other's system path configurations, causing programs installed by Micromamba (e.g., `meson`) not to be found. These live in `C:\Users\runneradmin\micromamba-root\envs\<your environment name>\Scripts`. The recommended pattern to avoid this problem is:
+
+1) use `mamba-org/provision-with-micromamba@main`
+2) use `modflowpy/install-intelfortran-action@v1`
+3) add a step with the following:
+
+```pwsh
+$mamba_bin = "C:\Users\runneradmin\micromamba-root\envs\<your environment name>\Scripts"
+echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 ```
 
-Or from a `cmd` shell:
+## License
 
-```
-set "PATH=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\bin\Hostx64\x64;%PATH%"
-```
-
-## Attribution
-
-This action is based on examples in the [OneApi repository](https://github.com/oneapi-src/oneapi-ci), which is copyrighted to Intel and distributed under the MIT license:
+This action is based on examples in the [oneAPI CI samples repository](https://github.com/oneapi-src/oneapi-ci), which are subject to the [oneAPI End User License Agreement](https://www.intel.com/content/www/us/en/developer/articles/license/end-user-license-agreement.html), copyrighted to Intel, and distributed under the MIT license:
 
 ```
 SPDX-FileCopyrightText: 2020 Intel Corporation

--- a/action.yml
+++ b/action.yml
@@ -1,173 +1,169 @@
 name: Install Intel Fortran
-description: Install & cache Intel Fortran
+description: Install, cache, and configure environment for the Intel Fortran compiler
+inputs:
+  path:
+    description: Path to install location
+    required: false
+    default: ~/.local/bin/ifort
+  # version:
+  #   description: Version of the intel oneAPI HPC toolkit to install
+  #   required: false
+  #   default: "2022.3"
+  # components:
+  #   description: Extra HPC toolkit components to install
+  #   required: false
+outputs:
+  cache-hit:
+    description: Whether the installation was restored from cache
+    value: ${{ steps.cache-ifort.outputs.cache-hit }}
 runs:
   using: composite
   steps:
-    - name: Set install path (Linux & Mac)
-      if: runner.os != 'Windows'
-      id: set-install-path
-      shell: bash
-      run: |
-        echo "::set-output name=install-path::/opt/intel/oneapi"
-
-    - name: Set resources (Linux)
-      if: runner.os == 'Linux'
-      id: set-resources-linux
-      shell: bash
-      run: |
-        echo "::set-output name=hpckit_url::https://registrationcenter-download.intel.com/akdlm/irc_nas/18679/l_HPCKit_p_2022.2.0.191_offline.sh"
-        echo "::set-output name=components::intel.oneapi.lin.ifort-compiler"
-
-    - name: Cache ifort (Linux)
-      if: runner.os == 'Linux'
-      id: cache-install-linux
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.set-install-path.outputs.install-path }}
-        key: ifort-${{ runner.os }}-${{ steps.set-resources-linux.outputs.hpckit_url }}-${{ steps.set-resources-linux.outputs.components }}
-
-    - name: Install ifort (Linux)
-      if: runner.os == 'Linux' && steps.cache-install-linux.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        # SPDX-FileCopyrightText: 2020 Intel Corporation
-        # SPDX-License-Identifier: MIT
-        curl --output webimage.sh --url "$HPCKIT_URL" --retry 5 --retry-delay 5
-        chmod +x webimage.sh
-        ./webimage.sh -x -f webimage_extracted --log extract.log
-        rm -rf webimage.sh
-        WEBIMAGE_NAME=$(ls -1 webimage_extracted/)
-        if [ -z "$COMPONENTS" ]; then
-          sudo webimage_extracted/"$WEBIMAGE_NAME"/bootstrapper -s --action install --eula=accept --log-dir=.
-          installer_exit_code=$?
-        else
-          sudo webimage_extracted/"$WEBIMAGE_NAME"/bootstrapper -s --action install --components="$COMPONENTS" --eula=accept --log-dir=.
-          installer_exit_code=$?
-        fi
-        rm -rf webimage_extracted
-        exit $installer_exit_code
-      env:
-        HPCKIT_URL: ${{ steps.set-resources-linux.outputs.hpckit_url }}
-        COMPONENTS: ${{ steps.set-resources-linux.outputs.components }}
-
-    - name: Exclude unused files from cache (Linux)
-      shell: bash
-      if: runner.os == 'Linux' && steps.cache-install-linux.outputs.cache-hit != 'true'
-      run: |
-        # SPDX-FileCopyrightText: 2020 Intel Corporation
-        # SPDX-License-Identifier: MIT
-        LATEST_VERSION=$(ls -1 /opt/intel/oneapi/compiler/ | grep -v latest | sort | tail -1)
-        sudo rm -rf /opt/intel/oneapi/compiler/"$LATEST_VERSION"/linux/compiler/lib/ia32_lin
-        sudo rm -rf /opt/intel/oneapi/compiler/"$LATEST_VERSION"/linux/bin/ia32
-        sudo rm -rf /opt/intel/oneapi/compiler/"$LATEST_VERSION"/linux/lib/emu
-        sudo rm -rf /opt/intel/oneapi/compiler/"$LATEST_VERSION"/linux/lib/oclfpga
-
-    - name: Set resources (Mac)
-      if: runner.os == 'macOS'
-      id: set-resources-macos
-      shell: bash
-      run: |
-        echo "::set-output name=hpckit_url::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18681/m_HPCKit_p_2022.2.0.158_offline.dmg"
-        echo "::set-output name=components::intel.oneapi.mac.ifort-compiler"
-
-    - name: Cache ifort (Mac)
-      if: runner.os == 'macOS'
-      id: cache-install-macos
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.set-install-path.outputs.install-path }}
-        key: ifort-${{ runner.os }}-${{ steps.set-resources-macos.outputs.hpckit_url }}-${{ steps.set-resources-macos.outputs.components }}
-
-    - name: Install ifort (Mac)
-      if: runner.os == 'macOS' && steps.cache-install-macos.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        # SPDX-FileCopyrightText: 2020 Intel Corporation
-        # SPDX-License-Identifier: MIT
-        curl --output webimage.dmg --url "$HPCKIT_URL" --retry 5 --retry-delay 5
-        hdiutil attach webimage.dmg
-        if [ -z "$COMPONENTS" ]; then
-          sudo /Volumes/"$(basename "$HPCKIT_URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --eula=accept --continue-with-optional-error=yes --log-dir=.
-          installer_exit_code=$?
-        else
-          sudo /Volumes/"$(basename "$HPCKIT_URL" .dmg)"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --components="$COMPONENTS" --eula=accept --log-dir=.
-          installer_exit_code=$?
-        fi
-        hdiutil detach /Volumes/"$(basename "$HPCKIT_URL" .dmg)" -quiet
-        exit $installer_exit_code
-      env:
-        HPCKIT_URL: ${{ steps.set-resources-macos.outputs.hpckit_url }}
-        COMPONENTS: ${{ steps.set-resources-macos.outputs.components }}
-
-    - name: Configure environment (Linux & Mac)
+    - name: Set install path
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        # set environment variables with script bundled with the install
-        source /opt/intel/oneapi/setvars.sh
+        # normalize install path
+        normalized=$(python3 $GITHUB_ACTION_PATH/scripts/normalize_path.py "${{ inputs.path }}")
+        echo "normalized bin dir path: $normalized"
         
-        # persist environment variables for the remainder of the workflow
-        env | grep oneapi >> $GITHUB_ENV
+        # set environment variable
+        echo "INTEL_HPCKIT_INSTALL_PATH=$normalized" >> $GITHUB_ENV
+        mkdir -p "$normalized"
 
-    - name: Set resources (Windows)
+    - name: Set install path
       if: runner.os == 'Windows'
-      id: set-resources-windows
       shell: pwsh
       run: |
-        echo "::set-output name=hpckit_url::https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18680/w_HPCKit_p_2022.2.0.173_offline.exe"
-        echo "::set-output name=components::intel.oneapi.win.ifort-compiler"
-
-    - name: Cache ifort (Windows)
-      if: runner.os == 'Windows'
-      id: cache-install-windows
-      uses: actions/cache@v3
-      with:
-        path: C:\Program Files (x86)\Intel\oneAPI
-        key: ifort-${{ runner.os }}-${{ steps.set-resources-windows.outputs.hpckit_url }}-${{ steps.set-resources-windows.outputs.components }}
-
-    - name: Install ifort (Windows)
-      if: runner.os == 'Windows' && steps.cache-install-windows.outputs.cache-hit != 'true'
-      shell: cmd
-      run: |
-        REM SPDX-FileCopyrightText: 2022 Intel Corporation
-        REM SPDX-License-Identifier: MIT
-        curl.exe --output %TEMP%\webimage.exe --url %HPCKIT_URL% --retry 5 --retry-delay 5
-        start /b /wait %TEMP%\webimage.exe -s -x -f webimage_extracted --log extract.log
-        del %TEMP%\webimage.exe
-        if "%COMPONENTS%"=="" (
-          webimage_extracted\bootstrapper.exe -s --action install --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
-        ) else (
-          webimage_extracted\bootstrapper.exe -s --action install --components=%COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=.
-        )
-        rd /s/q "webimage_extracted"
-      env:
-        HPCKIT_URL: ${{ steps.set-resources-windows.outputs.hpckit_url }}
-        COMPONENTS: ${{ steps.set-resources-windows.outputs.components }}
-    
-    - name: Configure environment (Windows)
-      if: runner.os == 'Windows'
-      shell: cmd
-      run: |
-        :: set environment variables
-        call "C:\Program Files (x86)\Intel\oneAPI\setvars-vcvarsall.bat" %VS_VER%
-        for /f "tokens=* usebackq" %%f in (`dir /b "C:\Program Files (x86)\Intel\oneAPI\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST_VERSION=%%f"
-        call "C:\Program Files (x86)\Intel\oneAPI\compiler\%LATEST_VERSION%\env\vars.bat"
+        # normalize install path
+        $normalized = $(python3 $(Join-Path "$env:GITHUB_ACTION_PATH" "scripts" "normalize_path.py") "${{ inputs.path }}")
+        echo "normalized bin dir path: $normalized"
         
-        :: persist environment variables for remainder of workflow
-        set | findstr /c:"oneAPI" >> %GITHUB_ENV%
-      env:
-        VS_VER: vs2022
+        # other locations fail on windows
+        $default = "C:\Program Files (x86)\Intel\oneAPI"
+        if (!($normalized -eq $default)) {
+          echo "overriding configured path with default Windows install path: '$default'"
+          $normalized = $default
+        }
+        
+        # set environment variable
+        echo "INTEL_HPCKIT_INSTALL_PATH=$normalized" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
+        md -Force "$normalized"  
 
-    - name: Exclude unused files from cache (Windows)
+    - name: Set environment variables
       shell: bash
-      if: runner.os == 'Windows' && steps.cache-install-windows.outputs.cache-hit != 'true'
       run: |
-        # SPDX-FileCopyrightText: 2020 Intel Corporation
-        # SPDX-License-Identifier: MIT
-        LATEST_VERSION=$(ls -1 "C:\Program Files (x86)\Intel\oneAPI\compiler" | grep -v latest | sort | tail -1)
-        rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\compiler\lib\ia32_win"
-        rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\bin\intel64_ia32"
-        rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\emu"
-        rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\oclfpga"
-        rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\ocloc"
-        rm -rf "C:\Program Files (x86)\Intel\oneAPI\compiler\'$LATEST_VERSION'\windows\lib\x86"
+        echo "setting toolkit variables"
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18679/l_HPCKit_p_2022.2.0.191_offline.sh" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.lin.ifort-compiler" >> $GITHUB_ENV
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18681/m_HPCKit_p_2022.2.0.158_offline.dmg" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.mac.ifort-compiler" >> $GITHUB_ENV
+        else
+          echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18680/w_HPCKit_p_2022.2.0.173_offline.exe" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.win.ifort-compiler" >> $GITHUB_ENV
+        fi
+ 
+        version="2022.3"
+        echo "using toolkit version $version"
+        echo "INTEL_HPCKIT_VERSION=$version" >> $GITHUB_ENV
+        echo "FC=ifort" >> $GITHUB_ENV
+
+    - name: Prepend tar exe to path
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        echo "C:\Windows\System32" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Restore cache
+      id: cache-ifort
+      uses: martijnhols/actions-cache/restore@v3
+      with:
+        path: ${{ env.INTEL_HPCKIT_INSTALL_PATH }}
+        key: ifort-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}
+
+    - name: Install Intel fortran
+      if: runner.os != 'Windows' && steps.cache-ifort.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        echo "downloading and running HPC kit installer"
+        os=$(echo $RUNNER_OS | tr '[:upper:]' '[:lower:]')
+        "${{ github.action_path }}/scripts/install_$os.sh" "${{ env.INTEL_HPCKIT_INSTALL_PATH }}" "${{ env.INTEL_HPCKIT_INSTALLER_URL }}" "${{ env.INTEL_HPCKIT_COMPONENTS }}"
+
+    - name: Install Intel fortran
+      if: runner.os == 'Windows' && steps.cache-ifort.outputs.cache-hit != 'true'
+      shell: cmd
+      run: |
+        :: download HPC kit installer and install Intel fortran
+        call "%GITHUB_ACTION_PATH%\scripts\install_windows.bat" "${{ env.INTEL_HPCKIT_INSTALL_PATH }}" "${{ env.INTEL_HPCKIT_INSTALLER_URL }}" "${{ env.INTEL_HPCKIT_COMPONENTS }}"
+
+    - name: Save cache
+      if: steps.cache-ifort.outputs.cache-hit != 'true'
+      uses: martijnhols/actions-cache/save@v3
+      with:
+        path: ${{ env.INTEL_HPCKIT_INSTALL_PATH }}
+        key: ifort-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}
+
+    - name: Configure system path
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        echo "getting os tag"
+        if [ "$RUNNER_OS" == "Linux" ]; then
+          ostag="linux"
+        
+          # workaround missing libimf.so error
+          # https://stackoverflow.com/a/70700494/6514033
+          sudo mkdir -p /etc/ld.so.conf.d
+          echo "$INTEL_HPCKIT_INSTALL_PATH/compiler/latest/$ostag/compiler/lib/intel64_lin" | sudo tee -a /etc/ld.so.conf.d/intel_libs.conf
+          sudo ldconfig
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          ostag="mac"
+        else
+          ostag="windows"
+        fi
+        
+        bindir="$INTEL_HPCKIT_INSTALL_PATH/compiler/latest/$ostag/bin/intel64"
+        echo "adding ifort compiler bin dir '$bindir' to path"
+        echo "$bindir" >> $GITHUB_PATH
+        echo "INTEL_COMPILER_BIN_PATH=$bindir" >> $GITHUB_ENV
+
+    - name: Configure system path
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        :: add compiler bin dir to path
+        set bindir=%INTEL_HPCKIT_INSTALL_PATH%\compiler\latest\windows\bin\intel64
+        echo adding ifort compiler bin dir '%bindir%' to path
+        echo %bindir%>>"%GITHUB_PATH"
+        echo INTEL_COMPILER_BIN_PATH=%bindir%>>"%GITHUB_ENV"
+        
+        :: prepend MSVC bindir to path
+        set bindir=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\bin\Hostx64\x64
+        echo adding MSVC linker bin dir '%bindir%' to path
+        echo %bindir%>>"%GITHUB_PATH%"
+
+    - name: Configure oneAPI environment
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        # configure oneAPI environment
+        # https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html#use-the-setvars-script-with-linux-or-macos
+        echo "configuring Intel environment"
+        source "$INTEL_HPCKIT_INSTALL_PATH/setvars.sh"
+        
+        echo "persisting oneAPI environment"
+        env | grep oneapi >> $GITHUB_ENV
+        
+    - name: Configure oneAPI environment
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        echo configuring oneAPI environment
+        :: call "%INTEL_HPCKIT_INSTALL_PATH%\setvars-vcvarsall.bat"
+        :: this script fails when install location is not the default
+        call "%INTEL_HPCKIT_INSTALL_PATH%\compiler\2022.1.0\env\vars.bat"
+        
+        echo persisting oneAPI environment
+        set | findstr /c:"oneAPI" >> "%GITHUB_ENV%"

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -1,0 +1,22 @@
+bin="$1"  # install location
+url="$2"  # download url
+cmp="$3"  # components
+ver="$4"  # version
+dmg=$(basename "$url" .dmg)
+
+curl --output webimage.sh --url "$url" --retry 5 --retry-delay 5
+chmod +x webimage.sh
+./webimage.sh -x -f webimage_extracted --log extract.log
+rm -rf webimage.sh
+WEBIMAGE_NAME=$(ls -1 webimage_extracted/)
+if [ -z "$cmp" ]; then
+  echo "installing version $ver with components $cmp"
+  sudo webimage_extracted/"$WEBIMAGE_NAME"/bootstrapper -s --action install --eula=accept --log-dir=. --install-dir "$bin" --product-ver "$ver"
+  installer_exit_code=$?
+else
+  echo "installing version $ver"
+  sudo webimage_extracted/"$WEBIMAGE_NAME"/bootstrapper -s --action install --components="$cmp" --eula=accept --log-dir=. --install-dir "$bin" --product-ver "$ver"
+  installer_exit_code=$?
+fi
+rm -rf webimage_extracted
+exit $installer_exit_code

--- a/scripts/install_macos.sh
+++ b/scripts/install_macos.sh
@@ -1,0 +1,19 @@
+bin="$1"  # install location
+url="$2"  # download url
+cmp="$3"  # components
+ver="$4"  # version
+dmg=$(basename "$url" .dmg)
+
+curl --output webimage.dmg --url "$url" --retry 5 --retry-delay 5
+hdiutil attach webimage.dmg
+if [ -z "$cmp" ]; then
+  echo "installing version $ver with components $cmp"
+  sudo /Volumes/"$dmg"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --eula=accept --continue-with-optional-error=yes --log-dir=. --install-dir "$bin" --product-ver "$ver"
+  installer_exit_code=$?
+else
+  echo "installing version $ver"
+  sudo /Volumes/"$dmg"/bootstrapper.app/Contents/MacOS/bootstrapper -s --action install --components="$cmp" --eula=accept --log-dir=. --install-dir "$bin" --product-ver "$ver"
+  installer_exit_code=$?
+fi
+hdiutil detach /Volumes/"$dmg" -quiet
+exit $installer_exit_code

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -1,0 +1,9 @@
+curl.exe --output %TEMP%\webimage.exe --url %2 --retry 5 --retry-delay 5
+start /b /wait %TEMP%\webimage.exe -s -x -f webimage_extracted --log extract.log
+del %TEMP%\webimage.exe
+if "%3"=="" (
+  webimage_extracted\bootstrapper.exe -s --action install --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=. --install-dir %1
+) else (
+  webimage_extracted\bootstrapper.exe -s --action install --components=default:%3 --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 -p=NEED_VS2022_INTEGRATION=0 --log-dir=. --install-dir %1
+)
+rd /s/q "webimage_extracted"

--- a/scripts/normalize_path.py
+++ b/scripts/normalize_path.py
@@ -1,0 +1,11 @@
+import os
+import sys
+from pathlib import Path
+
+path = sys.argv[1]
+if path.startswith('/') or path.startswith('\\'):
+    print(Path(path).resolve())
+elif path.startswith('~'):
+    print(Path(os.path.expanduser(path)).resolve())
+else:
+    print(os.path.realpath(Path(path).resolve()))

--- a/test/test.bat
+++ b/test/test.bat
@@ -1,0 +1,11 @@
+ifort test/hw.f90 -o hw
+
+FOR /F "tokens=* USEBACKQ" %%F IN (`hw`) DO (
+SET output=%%F
+)
+
+if /I "%output:hello=%" neq "%output%" (
+echo compile succeeded
+) else (
+echo "unexpected output: %output%" exit /b 1
+)

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -1,30 +1,31 @@
 $path=$args[0]
 if (!($path)) {
-    write-output "Must specify path argument"
+    write-output "must specify path argument"
     exit 1
 }
 
-if (test-path $path)
-{
-    write-output "Found install location: $path"
-} else {
-    write-output "Install location doesn't exist: $path"
-    exit 1
-}
+# if (test-path $path)
+# {
+#     write-output "install location exists: $path"
+# } else {
+#     write-output "install location doesn't exist: $path"
+#     exit 1
+# }
 
 if ((get-command "ifort" -ErrorAction SilentlyContinue) -eq $null) {
-    write-output "Command ifort not available"
+    write-output "ifort not available"
     exit 1
 } else {
-    write-output "Command ifort found"
+    write-output "ifort found"
+    ifort /QV
 }
 
 ifort test/hw.f90 -o hw
 $output=$(./hw)
 if ($output -match "hello world") {
-    write-output "Compile succeeded"
+    write-output "compile succeeded"
     write-output $output
 } else {
-    write-output "Unexpected output: $output"
+    write-output "unexpected output: $output"
     exit 1
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -3,23 +3,24 @@
 path="$1"
 if [ -z "$path" ]
 then
-  echo "Must specify path argument"
+  echo "must specify path argument"
   exit 1
 fi
 
 if [ -d "$path" ]
 then
-  echo "Install location exists: $path"
+  echo "install location exists: $path"
 else
-  echo "Install location doesn't exist: $path"
+  echo "install location doesn't exist: $path"
   exit 1
 fi
 
 if command -v ifort &> /dev/null
 then
-  echo "Command ifort available"
+  echo "ifort found"
+  ifort -h
 else
-  echo "Command ifort not available"
+  echo "ifort not available"
   exit 1
 fi
 
@@ -27,9 +28,9 @@ ifort test/hw.f90 -o hw
 output=$(./hw '2>&1')
 if [[ "$output" == *"hello world"* ]]
 then
-  echo "Compile succeeded"
+  echo "compile succeeded"
   echo "$output"
 else
-  echo "Unexpected output: $output"
+  echo "unexpected output: $output"
   exit 1
 fi


### PR DESCRIPTION
* move inline install scripts to files
* make steps cross-platform where possible
* replace `set-output` mechanism (soon [deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))
* test both `cmd` and `pwsh` on Windows
* save cache after install even if workflow fails
* set env vars for HPC kit, FC and install location
* fix #7: don't use GNU tar on Windows ([can't unpack symlinks](https://superuser.com/questions/1465200/symbolic-link-issue-extracting-tarball-on-windows))
* add MSVC linker bindir to system path
* workaround `libimf.so` missing issue on Linux
* make install location configurable (support relative, absolute and `~`-expanded paths)
* warn about windows caveats in README
  - must use default install location
  - must use `cmd` or `pwsh`, not `bash`
  - may need to set micromamba bin dir path