### PR TITLE
Miscellaneous

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - main
       - develop
-env:
-  FC: ifort
 jobs:
   test:
     name: Test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -66,7 +66,7 @@ jobs:
           meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
           meson compile -v -C builddir
           meson install -C builddir
-      - name: Add conda bindirs to path (Windows)
+      - name: Add micromamba Scripts dir to path (Windows)
         if: runner.os == 'Windows' && matrix.env == 'micromamba'
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ A few additional variables are also set:
 - `INTEL_HPCKIT_COMPONENT` is the compiler component installed (e.g. `intel.oneapi.win.ifort-compiler` for Windows)
 - `INTEL_COMPILER_BIN_PATH` is the location of compiler executables (this is equivalent to `$HPCKIT_INSTALL_PATH/compilers/latest/<mac, linux, or windows>/bin/intel64`, substituting the proper OS)
 - `INTEL_HPCKIT_VERSION` is the oneAPI HPC toolkit version number used (currently `2022.3`)
-- `FC` is the full path the `ifort` executable
+- `FC` is set to `ifort`
 
 **Note:** GitHub Actions does not preserve environment variables between steps by default &mdash; this action persists them via the [`GITHUB_ENV` environment file](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable).
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ A few additional variables are also set:
 - `INTEL_HPCKIT_COMPONENT` is the compiler component installed (e.g. `intel.oneapi.win.ifort-compiler` for Windows)
 - `INTEL_COMPILER_BIN_PATH` is the location of compiler executables (this is equivalent to `$HPCKIT_INSTALL_PATH/compilers/latest/<mac, linux, or windows>/bin/intel64`, substituting the proper OS)
 - `INTEL_HPCKIT_VERSION` is the oneAPI HPC toolkit version number used (currently `2022.3`)
+- `FC` is the full path the `ifort` executable
 
 **Note:** GitHub Actions does not preserve environment variables between steps by default &mdash; this action persists them via the [`GITHUB_ENV` environment file](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable).
 

--- a/action.yml
+++ b/action.yml
@@ -53,20 +53,20 @@ runs:
     - name: Set HPC kit environment variables
       shell: bash
       run: |
-        echo "setting toolkit variables"
+        echo "setting HPC toolkit variables"
+        version="2022.3.0"
         if [ "$RUNNER_OS" == "Linux" ]; then
-          echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18679/l_HPCKit_p_2022.2.0.191_offline.sh" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18856/l_HPCKit_p_$version.8751_offline.sh" >> $GITHUB_ENV
           echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.lin.ifort-compiler" >> $GITHUB_ENV
         elif [ "$RUNNER_OS" == "macOS" ]; then
-          echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18681/m_HPCKit_p_2022.2.0.158_offline.dmg" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18866/m_HPCKit_p_$version.8685_offline.dmg" >> $GITHUB_ENV
           echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.mac.ifort-compiler" >> $GITHUB_ENV
         else
-          echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18680/w_HPCKit_p_2022.2.0.173_offline.exe" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18857/w_HPCKit_p_$version.9564_offline.exe" >> $GITHUB_ENV
           echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.win.ifort-compiler" >> $GITHUB_ENV
         fi
  
-        version="2022.3"
-        echo "using toolkit version $version"
+        echo "using HPC toolkit version $version"
         echo "INTEL_HPCKIT_VERSION=$version" >> $GITHUB_ENV
         
     - name: Hide GNU tar
@@ -142,7 +142,8 @@ runs:
       shell: cmd
       run: |
         :: add compiler bin dir to path
-        set bindir=%INTEL_HPCKIT_INSTALL_PATH%\compiler\latest\windows\bin\intel64
+        for /f "tokens=* usebackq" %%f in (`dir /b "%INTEL_HPCKIT_INSTALL_PATH%\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST=%%f"
+        set bindir=%INTEL_HPCKIT_INSTALL_PATH%\compiler\%LATEST%\windows\bin\intel64
         echo adding ifort compiler bin dir '%bindir%' to path
         echo %bindir%>>"%GITHUB_PATH%"
         echo INTEL_COMPILER_BIN_PATH=%bindir%>>"%GITHUB_ENV%"
@@ -159,7 +160,7 @@ runs:
       run: |
         # configure oneAPI environment
         # https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-linux-or-macos.html#use-the-setvars-script-with-linux-or-macos
-        echo "configuring Intel environment"
+        echo "configuring oneAPI environment"
         source "$INTEL_HPCKIT_INSTALL_PATH/setvars.sh"
         
         echo "persisting oneAPI environment"
@@ -172,7 +173,8 @@ runs:
         echo configuring oneAPI environment
         call "%INTEL_HPCKIT_INSTALL_PATH%\setvars-vcvarsall.bat"
         :: this script fails when install location is not the default
-        call "%INTEL_HPCKIT_INSTALL_PATH%\compiler\2022.1.0\env\vars.bat"
+        for /f "tokens=* usebackq" %%f in (`dir /b "%INTEL_HPCKIT_INSTALL_PATH%\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST=%%f"
+        call "%INTEL_HPCKIT_INSTALL_PATH%\compiler\%LATEST%\env\vars.bat"
         
         echo persisting oneAPI environment
         set | findstr /c:"oneAPI" >> "%GITHUB_ENV%"

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
         echo "INTEL_HPCKIT_INSTALL_PATH=$normalized" | Out-File -FilePath "$env:GITHUB_ENV" -Encoding utf8 -Append
         md -Force "$normalized"  
 
-    - name: Set environment variables
+    - name: Set HPC kit environment variables
       shell: bash
       run: |
         echo "setting toolkit variables"
@@ -68,8 +68,7 @@ runs:
         version="2022.3"
         echo "using toolkit version $version"
         echo "INTEL_HPCKIT_VERSION=$version" >> $GITHUB_ENV
-        echo "FC=ifort" >> $GITHUB_ENV
-
+        
     - name: Hide GNU tar
       if: runner.os == 'windows'
       shell: bash
@@ -136,6 +135,7 @@ runs:
         echo "adding ifort compiler bin dir '$bindir' to path"
         echo "$bindir" >> $GITHUB_PATH
         echo "INTEL_COMPILER_BIN_PATH=$bindir" >> $GITHUB_ENV
+        echo "FC=ifort" >> $GITHUB_ENV
 
     - name: Configure system path
       if: runner.os == 'Windows'
@@ -144,8 +144,9 @@ runs:
         :: add compiler bin dir to path
         set bindir=%INTEL_HPCKIT_INSTALL_PATH%\compiler\latest\windows\bin\intel64
         echo adding ifort compiler bin dir '%bindir%' to path
-        echo %bindir%>>"%GITHUB_PATH"
-        echo INTEL_COMPILER_BIN_PATH=%bindir%>>"%GITHUB_ENV"
+        echo %bindir%>>"%GITHUB_PATH%"
+        echo INTEL_COMPILER_BIN_PATH=%bindir%>>"%GITHUB_ENV%"
+        echo FC=ifort>>"%GITHUB_ENV%"
         
         :: prepend MSVC bindir to path
         set bindir=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\bin\Hostx64\x64

--- a/test/test.sh
+++ b/test/test.sh
@@ -18,7 +18,6 @@ fi
 if command -v ifort &> /dev/null
 then
   echo "ifort found"
-  ifort -h
 else
   echo "ifort not available"
   exit 1


### PR DESCRIPTION
Previously HPC kit installer version 2022.2.0 was used by mistake due to a stale URL. This PR updates the action to use 2022.3.0. (This does not change the compiler distribution version and should not have any functional effect as a bit confusingly the compiler dist is 2022.2.0 for both HPC kit versions.) Also mention the `FC` env var in the README, fix a minor issue with tests using a non-existent `ifort` flag `-h`, and find the compiler bin dir name on Windows (since `latest` symlink doesn't work).