### PR TITLE
feat(C/C++): include C/C++ classic compiler components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,19 +52,19 @@ jobs:
           }
 
           echo "TEST_BINDIR=$bindir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - name: Install ifort
+      - name: Install compilers
         if: matrix.path != 'default'
         uses: ./
         with:
           path: ${{ env.TEST_BINDIR }}
-      - name: Install ifort
+      - name: Install compilers
         if: matrix.path == 'default'
         uses: ./
-      - name: Test ifort (Linux & Mac)
+      - name: Test compilers (Linux & Mac)
         if: runner.os != 'Windows'
         run: |
           ./test/test.sh ${{ env.TEST_BINDIR }}
-      - name: Test ifort (Windows bash)
+      - name: Test compilers (Windows bash)
         if: runner.os == 'Windows'
         shell: bash
         run: |
@@ -89,12 +89,12 @@ jobs:
             echo "unexpected output: $output"
             exit 1
           fi
-      - name: Test ifort (Windows pwsh)
+      - name: Test compilers (Windows pwsh)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           ./test/test.ps1 "${{ env.TEST_BINDIR }}"
-      - name: Test ifort (Windows cmd)
+      - name: Test compilers (Windows cmd)
         if: runner.os == 'Windows'
         shell: cmd
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ on:
   push:
     branches:
       - main
-      - develop
+      - develop*
   pull_request:
     branches:
       - main
-      - develop
+      - develop*
 jobs:
   test:
     name: Test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,8 +41,8 @@ jobs:
           cache: 'pip'
       - name: Install Python dependencies
         if: matrix.env == 'pip'
-        run: |
-          pip3 install -r test/requirements.txt
+        shell: bash
+        run: pip install -r test/requirements.txt
       - name: Install miniconda environment
         if: matrix.env == 'miniconda'
         uses: conda-incubator/setup-miniconda@v2
@@ -60,7 +60,15 @@ jobs:
         with:
           path: ${{ runner.os != 'Windows' && 'bin' || 'C:\Program Files (x86)\Intel\oneAPI' }}
       - name: Build modflow6 (Linux & Mac)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && matrix.env == 'pip'
+        working-directory: modflow6
+        shell: bash
+        run: |
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          meson compile -v -C builddir
+          meson install -C builddir
+      - name: Build modflow6 (Linux & Mac)
+        if: runner.os != 'Windows' && matrix.env != 'pip'
         working-directory: modflow6
         run: |
           meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/modflowpy/install-intelfortran-action/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/modflowpy/install-intelfortran-action/actions/workflows/ci.yml)
 
-An action to install and cache the [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran classic compiler via the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy) and add `ifort` to the path.
+An action to install and cache the [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran and C/C++ classic compilers via the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -24,7 +24,7 @@ An action to install and cache the [Intel OneAPI](https://www.intel.com/content/
 
 ## Overview
 
-This action installs the [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran compiler. It does this by downloading and running the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy) offline installer, selecting only the `ifort-compiler` component. After installing the compiler distribution, the action configures [environment variables](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup.html) necessary to invoke `ifort` from subsequent workflow steps.
+This action installs the [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran and C/C++ classic compilers. It does this by downloading and running the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy) offline installer, selecting only the `ifort-compiler` component. After installing the compiler distribution, the action configures [environment variables](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup.html) necessary to invoke `ifort` or `icc` (`icl` on Windows) from subsequent workflow steps.
 
 ## Usage
 
@@ -67,6 +67,7 @@ A few additional variables are also set:
 - `INTEL_COMPILER_BIN_PATH` is the location of compiler executables (this is equivalent to `$HPCKIT_INSTALL_PATH/compilers/latest/<mac, linux, or windows>/bin/intel64`, substituting the proper OS)
 - `INTEL_HPCKIT_VERSION` is the oneAPI HPC toolkit version number used (currently `2022.3`)
 - `FC` is set to `ifort`
+- `CC` is set to `icc` on Linux and macOS and `icl` on Windows
 
 **Note:** GitHub Actions does not preserve environment variables between steps by default &mdash; this action persists them via the [`GITHUB_ENV` environment file](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable).
 

--- a/action.yml
+++ b/action.yml
@@ -31,7 +31,7 @@ runs:
         echo "INTEL_HPCKIT_INSTALL_PATH=$normalized" >> $GITHUB_ENV
         mkdir -p "$normalized"
 
-    - name: Set install path
+    - name: Set install path (Windows)
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
@@ -57,13 +57,13 @@ runs:
         version="2022.3.0"
         if [ "$RUNNER_OS" == "Linux" ]; then
           echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18856/l_HPCKit_p_$version.8751_offline.sh" >> $GITHUB_ENV
-          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.lin.mpi.devel:intel.oneapi.lin.dpcpp-cpp-compiler-pro:intel.oneapi.lin.ifort-compiler" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.lin.dpcpp-cpp-compiler-pro:intel.oneapi.lin.ifort-compiler" >> $GITHUB_ENV
         elif [ "$RUNNER_OS" == "macOS" ]; then
           echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18866/m_HPCKit_p_$version.8685_offline.dmg" >> $GITHUB_ENV
           echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.mac.cpp-compiler:intel.oneapi.mac.ifort-compiler" >> $GITHUB_ENV
         else
           echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18857/w_HPCKit_p_$version.9564_offline.exe" >> $GITHUB_ENV
-          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.win.mpi.devel:intel.oneapi.win.cpp-compiler:intel.oneapi.win.ifort-compiler" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.win.cpp-compiler:intel.oneapi.win.ifort-compiler" >> $GITHUB_ENV
         fi
  
         echo "using HPC toolkit version $version"
@@ -90,7 +90,7 @@ runs:
         # restore GNU tar
         mv "$RUNNER_TEMP\tar.exe" 'C:\Program Files\Git\usr\bin\tar.exe'
 
-    - name: Install Intel fortran
+    - name: Install compilers
       if: runner.os != 'Windows' && steps.cache-ifort.outputs.cache-hit != 'true'
       shell: bash
       run: |
@@ -98,7 +98,7 @@ runs:
         os=$(echo $RUNNER_OS | tr '[:upper:]' '[:lower:]')
         "${{ github.action_path }}/scripts/install_$os.sh" "${{ env.INTEL_HPCKIT_INSTALL_PATH }}" "${{ env.INTEL_HPCKIT_INSTALLER_URL }}" "${{ env.INTEL_HPCKIT_COMPONENTS }}"
 
-    - name: Install Intel fortran
+    - name: Install compilers (Windows)
       if: runner.os == 'Windows' && steps.cache-ifort.outputs.cache-hit != 'true'
       shell: cmd
       run: |
@@ -136,9 +136,10 @@ runs:
         echo "$bindir" >> $GITHUB_PATH
         echo "INTEL_COMPILER_BIN_PATH=$bindir" >> $GITHUB_ENV
         echo "FC=ifort" >> $GITHUB_ENV
+        echo "CC=icc" >> $GITHUB_ENV
         echo "ONEAPI_ROOT=$INTEL_HPCKIT_INSTALL_PATH" >> $GITHUB_ENV
 
-    - name: Configure system path
+    - name: Configure system path (Windows)
       if: runner.os == 'Windows'
       shell: cmd
       run: |
@@ -149,6 +150,7 @@ runs:
         echo %bindir%>>"%GITHUB_PATH%"
         echo INTEL_COMPILER_BIN_PATH=%bindir%>>"%GITHUB_ENV%"
         echo FC=ifort>>"%GITHUB_ENV%"
+        echo CC=icl>>"%GITHUB_ENV%"
         echo ONEAPI_ROOT=%INTEL_HPCKIT_INSTALL_PATH%>>"%GITHUB_ENV%"
         
         :: prepend MSVC bindir to path

--- a/action.yml
+++ b/action.yml
@@ -57,13 +57,13 @@ runs:
         version="2022.3.0"
         if [ "$RUNNER_OS" == "Linux" ]; then
           echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18856/l_HPCKit_p_$version.8751_offline.sh" >> $GITHUB_ENV
-          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.lin.ifort-compiler" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.lin.mpi.devel:intel.oneapi.lin.dpcpp-cpp-compiler-pro:intel.oneapi.lin.ifort-compiler" >> $GITHUB_ENV
         elif [ "$RUNNER_OS" == "macOS" ]; then
           echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18866/m_HPCKit_p_$version.8685_offline.dmg" >> $GITHUB_ENV
-          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.mac.ifort-compiler" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.mac.cpp-compiler:intel.oneapi.mac.ifort-compiler" >> $GITHUB_ENV
         else
           echo "INTEL_HPCKIT_INSTALLER_URL=https://registrationcenter-download.intel.com/akdlm/irc_nas/18857/w_HPCKit_p_$version.9564_offline.exe" >> $GITHUB_ENV
-          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.win.ifort-compiler" >> $GITHUB_ENV
+          echo "INTEL_HPCKIT_COMPONENTS=intel.oneapi.win.mpi.devel:intel.oneapi.win.cpp-compiler:intel.oneapi.win.ifort-compiler" >> $GITHUB_ENV
         fi
  
         echo "using HPC toolkit version $version"

--- a/action.yml
+++ b/action.yml
@@ -136,6 +136,7 @@ runs:
         echo "$bindir" >> $GITHUB_PATH
         echo "INTEL_COMPILER_BIN_PATH=$bindir" >> $GITHUB_ENV
         echo "FC=ifort" >> $GITHUB_ENV
+        echo "ONEAPI_ROOT=$INTEL_HPCKIT_INSTALL_PATH" >> $GITHUB_ENV
 
     - name: Configure system path
       if: runner.os == 'Windows'
@@ -148,6 +149,7 @@ runs:
         echo %bindir%>>"%GITHUB_PATH%"
         echo INTEL_COMPILER_BIN_PATH=%bindir%>>"%GITHUB_ENV%"
         echo FC=ifort>>"%GITHUB_ENV%"
+        echo ONEAPI_ROOT=%INTEL_HPCKIT_INSTALL_PATH%>>"%GITHUB_ENV%"
         
         :: prepend MSVC bindir to path
         set bindir=C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\bin\Hostx64\x64

--- a/action.yml
+++ b/action.yml
@@ -81,7 +81,7 @@ runs:
       uses: martijnhols/actions-cache/restore@v3
       with:
         path: ${{ env.INTEL_HPCKIT_INSTALL_PATH }}
-        key: ifort-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}
+        key: intelfortran-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}
 
     - name: Restore GNU tar
       if: runner.os == 'windows'
@@ -110,7 +110,7 @@ runs:
       uses: martijnhols/actions-cache/save@v3
       with:
         path: ${{ env.INTEL_HPCKIT_INSTALL_PATH }}
-        key: ifort-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}
+        key: intelfortran-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}
 
     - name: Configure system path
       if: runner.os != 'Windows'

--- a/test/hw.cpp
+++ b/test/hw.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+using namespace std;
+int main() {
+   cout << "hello world" << endl;
+   return 0;
+}

--- a/test/test.bat
+++ b/test/test.bat
@@ -5,7 +5,33 @@ SET output=%%F
 )
 
 if /I "%output:hello=%" neq "%output%" (
-echo compile succeeded
+echo fortran compile succeeded
 ) else (
 echo "unexpected output: %output%" exit /b 1
+)
+
+del hw
+icl test/hw.cpp -o hw
+
+FOR /F "tokens=* USEBACKQ" %%F IN (`hw`) DO (
+SET output=%%F
+)
+
+if /I "%output:hello=%" neq "%output%" (
+echo icl compile succeeded
+) else (
+echo "icl unexpected output: %output%" exit /b 1
+)
+
+del hw
+icx test/hw.cpp -o hw
+
+FOR /F "tokens=* USEBACKQ" %%F IN (`hw`) DO (
+SET output=%%F
+)
+
+if /I "%output:hello=%" neq "%output%" (
+echo icx compile succeeded
+) else (
+echo "icx unexpected output: %output%" exit /b 1
 )

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -20,24 +20,24 @@ if ((get-command "ifort" -ErrorAction SilentlyContinue) -eq $null) {
     ifort /QV
 }
 
-if ((get-command "icpc" -ErrorAction SilentlyContinue) -eq $null) {
-    write-output "icpc not available"
+if ((get-command "icl" -ErrorAction SilentlyContinue) -eq $null) {
+    write-output "icl not available"
     exit 1
 } else {
-    write-output "icpc found"
-    icc /QV
+    write-output "icl found"
+    icl /QV
 }
 
-if ((get-command "icpx" -ErrorAction SilentlyContinue) -eq $null) {
-    write-output "icpx not available"
+if ((get-command "icx" -ErrorAction SilentlyContinue) -eq $null) {
+    write-output "icx not available"
     exit 1
 } else {
-    write-output "icpx found"
+    write-output "icx found"
     icx /QV
 }
 
-ifort test/hw.f90 -o hw
-$output=$(./hw)
+ifort test/hw.f90 -o hw.exe
+$output=$(./hw.exe)
 if ($output -match "hello world") {
     write-output "ifort compile succeeded"
     write-output $output
@@ -46,9 +46,9 @@ if ($output -match "hello world") {
     exit 1
 }
 
-sudo rm -rf hw
-icl test/hw.cpp -o hw
-$output=$(./hw)
+rm -Force hw.exe
+icl test/hw.cpp -o hw.exe
+$output=$(./hw.exe)
 if ($output -match "hello world") {
     write-output "icl compile succeeded"
     write-output $output
@@ -57,9 +57,9 @@ if ($output -match "hello world") {
     exit 1
 }
 
-sudo rm -rf hw
-icx test/hw.cpp -o hw
-$output=$(./hw)
+rm -Force hw.exe
+icx test/hw.cpp -o hw.exe
+$output=$(./hw.exe)
 if ($output -match "hello world") {
     write-output "icx compile succeeded"
     write-output $output

--- a/test/test.ps1
+++ b/test/test.ps1
@@ -20,12 +20,50 @@ if ((get-command "ifort" -ErrorAction SilentlyContinue) -eq $null) {
     ifort /QV
 }
 
+if ((get-command "icpc" -ErrorAction SilentlyContinue) -eq $null) {
+    write-output "icpc not available"
+    exit 1
+} else {
+    write-output "icpc found"
+    icc /QV
+}
+
+if ((get-command "icpx" -ErrorAction SilentlyContinue) -eq $null) {
+    write-output "icpx not available"
+    exit 1
+} else {
+    write-output "icpx found"
+    icx /QV
+}
+
 ifort test/hw.f90 -o hw
 $output=$(./hw)
 if ($output -match "hello world") {
-    write-output "compile succeeded"
+    write-output "ifort compile succeeded"
     write-output $output
 } else {
-    write-output "unexpected output: $output"
+    write-output "ifort unexpected output: $output"
+    exit 1
+}
+
+sudo rm -rf hw
+icl test/hw.cpp -o hw
+$output=$(./hw)
+if ($output -match "hello world") {
+    write-output "icl compile succeeded"
+    write-output $output
+} else {
+    write-output "icl unexpected output: $output"
+    exit 1
+}
+
+sudo rm -rf hw
+icx test/hw.cpp -o hw
+$output=$(./hw)
+if ($output -match "hello world") {
+    write-output "icx compile succeeded"
+    write-output $output
+} else {
+    write-output "icx unexpected output: $output"
     exit 1
 }

--- a/test/test.sh
+++ b/test/test.sh
@@ -17,17 +17,21 @@ fi
 
 if command -v ifort &> /dev/null
 then
-  echo "ifort found"
+  echo "Fortran classic compiler found"
 else
-  echo "ifort not available"
+  echo "Fortran classic compiler not available"
   exit 1
 fi
 
-if command -v icpc &> /dev/null
-then
-  echo "icpc found"
+if [[ ( "$OSTYPE" == "cygwin" ) || ( "$OSTYPE" == "msys" ) || ( "$OSTYPE" == "win32" ) ]]; then
+  cmd=$(command -v icl)
 else
-  echo "icpc not available"
+  cmd=$(command -v icpc)
+fi
+if [ "$cmd" ]; then
+  echo "C/C++ classic compiler found"
+else
+  echo "C/C++ classic compiler not available"
   exit 1
 fi
 
@@ -47,22 +51,27 @@ ifort test/hw.f90 -o hw
 output=$(./hw '2>&1')
 if [[ "$output" == *"hello world"* ]]
 then
-  echo "ifort compile succeeded"
+  echo "Fortran program compilation succeeded"
   echo "$output"
 else
-  echo "ifort unexpected output: $output"
+  echo "Fortran program gave unexpected output: $output"
   exit 1
 fi
 
 sudo rm -rf hw
-icpc test/hw.cpp -o hw
-output=$(./hw '2>&1')
+if [[ ( "$OSTYPE" == "cygwin" ) || ( "$OSTYPE" == "msys" ) || ( "$OSTYPE" == "win32" ) ]]; then
+  icl test/hw.cpp -o hw.exe
+  output=$(./hw.exe '2>&1')
+else
+  icpc test/hw.cpp -o hw
+  output=$(./hw '2>&1')
+fi
 if [[ "$output" == *"hello world"* ]]
 then
-  echo "icpc compile succeeded"
+  echo "C++ program compilation succeeded"
   echo "$output"
 else
-  echo "icpc unexpected output: $output"
+  echo "C++ program gave unexpected output: $output"
   exit 1
 fi
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -23,13 +23,61 @@ else
   exit 1
 fi
 
+if command -v icpc &> /dev/null
+then
+  echo "icpc found"
+else
+  echo "icpc not available"
+  exit 1
+fi
+
+# if [[ "$OSTYPE" == "darwin"* ]]; then
+#   echo "DPC++/C++ not supported on macOS, use classic compilers instead"
+# else
+#   if command -v icpx &> /dev/null
+#   then
+#     echo "icpx found"
+#   else
+#     echo "icpx not available"
+#     exit 1
+#   fi
+# fi
+
 ifort test/hw.f90 -o hw
 output=$(./hw '2>&1')
 if [[ "$output" == *"hello world"* ]]
 then
-  echo "compile succeeded"
+  echo "ifort compile succeeded"
   echo "$output"
 else
-  echo "unexpected output: $output"
+  echo "ifort unexpected output: $output"
   exit 1
 fi
+
+sudo rm -rf hw
+icpc test/hw.cpp -o hw
+output=$(./hw '2>&1')
+if [[ "$output" == *"hello world"* ]]
+then
+  echo "icpc compile succeeded"
+  echo "$output"
+else
+  echo "icpc unexpected output: $output"
+  exit 1
+fi
+
+# if [[ "$OSTYPE" == "darwin"* ]]; then
+#   echo "DPC++/C++ not supported on macOS, use classic compilers instead"
+# else
+#   sudo rm -rf hw
+#   icpx test/hw.cpp -o hw
+#   output=$(./hw '2>&1')
+#   if [[ "$output" == *"hello world"* ]]
+#   then
+#     echo "icpx compile succeeded"
+#     echo "$output"
+#   else
+#     echo "icpx unexpected output: $output"
+#     exit 1
+#   fi
+# fi


### PR DESCRIPTION
- install C/C++ classic compiler components from the HPC kit
- set `ONEAPI_ROOT` env var (`pymake` [expects](https://github.com/modflowpy/pymake/blob/bf7fb24fcc1f5669026d1c09d28961aaff438eb7/pymake/pymake_base.py#L1127) this or `LATEST_VERSION` to be set if `ifort` is used)
- fix failing integration test (use `shell: bash` for `pip install ...` instead of `shell: bash -l {0}`)