### PR TITLE
fix(Windows): fix Windows environment, expand runner test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022 ]
         path: [ absolute, relative, tilde, default ]
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,12 @@ jobs:
       matrix:
         os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022 ]
         path: [ absolute, relative, tilde, default ]
+        setvars: [ 'true', 'false' ]
     steps:
+
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Set bin path
         if: runner.os != 'Windows'
         run: |
@@ -36,6 +39,7 @@ jobs:
           fi
 
           echo "TEST_BINDIR=$bindir" >> $GITHUB_ENV
+
       - name: Set bin path (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -53,18 +57,44 @@ jobs:
           }
 
           echo "TEST_BINDIR=$bindir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
       - name: Install compilers
         if: matrix.path != 'default'
         uses: ./
         with:
           path: ${{ env.TEST_BINDIR }}
+          setvars: ${{ matrix.setvars }}
+
       - name: Install compilers
         if: matrix.path == 'default'
         uses: ./
+        with:
+          setvars: ${{ matrix.setvars }}
+
+      - name: Set environment variables
+        if: runner.os != 'Windows' && matrix.setvars != 'true'
+        shell: bash
+        run: |
+          source "$INTEL_HPCKIT_INSTALL_PATH/setvars.sh"
+          env | grep oneapi >> $GITHUB_ENV
+
+      - name: Set environment variables
+        if: runner.os == 'Windows' && matrix.setvars != 'true'
+        shell: cmd
+        run: |
+          call "%INTEL_HPCKIT_INSTALL_PATH%\compiler\%INTEL_COMPILER_VERSION%\env\vars.bat"
+          set | findstr /c:"oneAPI" >> "%GITHUB_ENV%"
+
+      # not needed atm, but just in case any future tests require this
+      - name: Set SETVARS_COMPLETED
+        if: matrix.setvars != 'true'
+        shell: bash
+        run: echo "SETVARS_COMPLETED=1" >> $GITHUB_ENV
+
       - name: Test compilers (Linux & Mac)
         if: runner.os != 'Windows'
-        run: |
-          ./test/test.sh ${{ env.TEST_BINDIR }}
+        run: ./test/test.sh ${{ env.TEST_BINDIR }}
+
       - name: Test compilers (Windows bash)
         if: runner.os == 'Windows'
         shell: bash
@@ -87,13 +117,13 @@ jobs:
             echo "unexpected output: $output"
             exit 1
           fi
+
       - name: Test compilers (Windows pwsh)
         if: runner.os == 'Windows'
         shell: pwsh
-        run: |
-          ./test/test.ps1 "${{ env.TEST_BINDIR }}"
+        run: ./test/test.ps1 "${{ env.TEST_BINDIR }}"
+
       - name: Test compilers (Windows cmd)
         if: runner.os == 'Windows'
         shell: cmd
-        run: |
-          call "./test/test.bat"
+        run: call "./test/test.bat"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,8 +16,8 @@ on:
   schedule:
     - cron: '0 6 * * *' # run at 6 AM UTC every day
 jobs:
-  test_build_modflow:
-    name: Test build modflow6
+  test_modflow:
+    name: Test modflow6 integration
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -31,28 +31,34 @@ jobs:
           # https://github.com/mamba-org/provision-with-micromamba#important
           bash -l {0}
     steps:
+
       - name: Checkout action
         uses: actions/checkout@v3
+
       - name: Checkout modflow6
         uses: actions/checkout@v3
         with:
           repository: MODFLOW-USGS/modflow6
           path: modflow6
+
       - name: Setup Python
         if: matrix.env == 'pip'
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
           cache: 'pip'
+
       - name: Install Python dependencies
         if: matrix.env == 'pip'
         shell: bash
         run: pip install -r test/requirements.txt
+
       - name: Install miniconda environment
         if: matrix.env == 'miniconda'
         uses: conda-incubator/setup-miniconda@v2
         with:
           environment-file: modflow6/environment.yml
+
       - name: Install micromamba environment
         if: matrix.env == 'micromamba'
         uses: mamba-org/provision-with-micromamba@main
@@ -60,10 +66,12 @@ jobs:
           environment-file: modflow6/environment.yml
           cache-downloads: true
           cache-env: true
+
       - name: Install ifort
         uses: ./
         with:
           path: ${{ runner.os != 'Windows' && 'bin' || 'C:\Program Files (x86)\Intel\oneAPI' }}
+
       - name: Build modflow6 (Linux & Mac)
         if: runner.os != 'Windows' && matrix.env == 'pip'
         working-directory: modflow6
@@ -72,6 +80,7 @@ jobs:
           meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
           meson compile -v -C builddir
           meson install -C builddir
+
       - name: Build modflow6 (Linux & Mac)
         if: runner.os != 'Windows' && matrix.env != 'pip'
         working-directory: modflow6
@@ -79,6 +88,7 @@ jobs:
           meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
           meson compile -v -C builddir
           meson install -C builddir
+
       - name: Add micromamba Scripts dir to path (Windows)
         if: runner.os == 'Windows' && matrix.env == 'micromamba'
         shell: pwsh
@@ -90,6 +100,7 @@ jobs:
             echo "adding micromamba scripts dir to path: $mamba_bin"
             echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           }
+
       - name: Build modflow6 (Windows bash)
         if: runner.os == 'Windows'
         continue-on-error: true
@@ -99,8 +110,10 @@ jobs:
           meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
           meson compile -v -C builddir
           meson install -C builddir
+
       - name: Show meson build log
         run: cat modflow6/builddir/meson-logs/meson-log.txt
+
       - name: Build modflow6 (Windows pwsh)
         if: runner.os == 'Windows'
         continue-on-error: true
@@ -110,6 +123,7 @@ jobs:
           meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin --wipe
           meson compile -v -C builddir
           meson install -C builddir
+
       - name: Build modflow6 (Windows cmd)
         if: runner.os == 'Windows'
         working-directory: modflow6
@@ -118,3 +132,58 @@ jobs:
           meson setup builddir -Ddebug=false --prefix=%CD% --libdir=bin --wipe
           meson compile -v -C builddir
           meson install -C builddir
+
+  test_pymake:
+    name: Test pymake integration
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # windows-2022 runners have Visual Studio 17.4.*, which oneapi toolchain doesn't support yet
+        os: [ ubuntu-latest, macos-latest, windows-2019 ]
+        env: [ pip, miniconda, micromamba ]
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          repository: modflowpy/pymake
+          path: pymake
+
+      - name: Setup Graphviz
+        if: runner.os == 'Linux'
+        uses: ts-graphviz/setup-graphviz@v1
+
+      - name: Set up Python
+        uses: actions/setup-python@v4.3.0
+        with:
+          python-version: 3.9
+
+      - name: Install Python packages
+        working-directory: pymake
+        run: .github/common/install-python.sh
+
+      - name: Setup oneAPI compilers
+        uses: ./
+        with:
+          path: ${{ runner.os != 'Windows' && 'bin' || 'C:\Program Files (x86)\Intel\oneAPI' }}
+
+      - name: Download examples
+        working-directory: pymake
+        run: .github/common/download-examples.sh
+
+      - name: Test (Linux)
+        if: runner.os == 'Linux'
+        working-directory: pymake
+        run: pytest -v -n=auto --dist=loadfile -m="base or regression" --durations=0 --cov=pymake --cov-report=xml autotest/
+
+      - name: Test (MacOS)
+        if: runner.os == 'macOS'
+        working-directory: pymake
+        run: pytest -v -n=auto --dist=loadfile -m="base" --durations=0 --cov=pymake --cov-report=xml autotest/
+
+      - name: Test (Windows)
+        if: runner.os == 'Windows'
+        working-directory: pymake
+        shell: cmd
+        run: pytest -v -m="base" --durations=0 --cov=pymake --cov-report=xml autotest/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,4 +1,4 @@
-name: MODFLOW 6 integration testing
+name: Integration testing
 on:
   push:
     branches:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -141,7 +141,6 @@ jobs:
       matrix:
         # windows-2022 runners have Visual Studio 17.4.*, which oneapi toolchain doesn't support yet
         os: [ ubuntu-latest, macos-latest, windows-2019 ]
-        env: [ pip, miniconda, micromamba ]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -142,9 +142,15 @@ jobs:
         # windows-2022 runners have Visual Studio 17.4.*, which oneapi toolchain doesn't support yet
         os: [ ubuntu-latest, macos-latest, windows-2019 ]
         env: [ pip, miniconda, micromamba ]
+    defaults:
+      run:
+        shell: bash
     steps:
 
-      - name: Checkout repo
+      - name: Checkout action
+        uses: actions/checkout@v3
+
+      - name: Checkout pymake
         uses: actions/checkout@v3
         with:
           repository: modflowpy/pymake

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ bin-release/
 
 # IDE
 .idea
+
+*.log

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ There are a few things to be aware of when using this action on Windows runners.
 
 ### Bash & MSVC
 
-This action uses [`ilammy/msvc-dev-cmd`](https://github.com/ilammy/msvc-dev-cmd) internally to configure the MSVC toolchain. Unfortunately, GitHub Actions automatically prepends GNU bin paths to the system path before running `bash` shell steps. This causes the GNU linker to be found even if the MSVC bin directory is on the path (more info [here](https://github.com/ilammy/msvc-dev-cmd#name-conflicts-with-shell-bash)). To make sure the MSVC toolchain is selected in `bash` steps on Windows, this action hides the GNU linker, moving it from `/usr/bin/link` to `$RUNNER_TEMP/link`.
+GitHub Actions prepends GNU bin paths to the system path before running `bash` shell steps. This causes the GNU linker to be found even if the MSVC bin directory is on the path (more info [here](https://github.com/ilammy/msvc-dev-cmd#name-conflicts-with-shell-bash)). To make sure the MSVC toolchain is selected in `bash` steps on Windows, this action hides the GNU linker, moving it from `/usr/bin/link` to `$RUNNER_TEMP/link`.
 
 ### Install location
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,19 @@
 [![CI](https://github.com/modflowpy/install-intelfortran-action/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/modflowpy/install-intelfortran-action/actions/workflows/ci.yml)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 
-An action to install and cache the [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran and C/C++ classic compilers via the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy).
+An action to install and cache [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran and C/C++ compilers via the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Overview](#overview)
 - [Usage](#usage)
+- [Environment variables](#environment-variables)
 - [Inputs](#inputs)
   - [`path`](#path)
-- [Environment variables](#environment-variables)
+  - [`setvars`](#setvars)
+    - [Setting oneAPI variables on Linux/macOS](#setting-oneapi-variables-on-linuxmacos)
+    - [Setting oneAPI variables on Windows](#setting-oneapi-variables-on-windows)
 - [Windows caveats](#windows-caveats)
   - [Bash & MSVC](#bash--msvc)
   - [Visual Studio](#visual-studio)
@@ -24,7 +27,7 @@ An action to install and cache the [Intel OneAPI](https://www.intel.com/content/
 
 ## Overview
 
-This action installs the [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran and C/C++ classic compilers via the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy) offline installer. After installation, the action configures [environment variables](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup.html) necessary to invoke the compilers from subsequent workflow steps.
+This action installs [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran and C/C++ compilers via the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy) offline installer. After installation, the action can optionally configure [environment variables](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup.html) necessary to invoke the compilers from subsequent workflow steps.
 
 ## Usage
 
@@ -35,9 +38,28 @@ To use this action, add a step like the following to your workflow:
   uses: modflowpy/install-intelfortran-action@v1
 ```
 
+By default, this action runs oneAPI `setvars` scripts to configure the environment for use. If you would rather run the oneAPI environment configuration scripts yourself, set the `setvars` input to `false`.
+
+## Environment variables
+
+Besides oneAPI environment variables configured by `setvars` scripts (whose names share substring `ONEAPI`), this action sets some additional variables:
+
+- `INTEL_HPCKIT_INSTALL_PATH` points to the top-level install path
+- `INTEL_HPCKIT_INSTALLER_URL` is the URL of the installer used
+- `INTEL_HPCKIT_COMPONENTS` is a `:`-delimited list of compiler components installed (e.g. `intel.oneapi.win.cpp-compiler:intel.oneapi.win.ifort-compiler` for Windows)
+- `INTEL_HPCKIT_VERSION` is the oneAPI HPC toolkit version number used (currently `2022.3`)
+- `INTEL_COMPILER_BIN_PATH` is the location of compiler executables (this is equivalent to `$HPCKIT_INSTALL_PATH/compilers/latest/<mac, linux, or windows>/bin/intel64`, substituting the proper OS)
+- `INTEL_COMPILER_VERSION` is the version of the installed compilers (this may be different than the version of the oneAPI HPC Toolkit)
+- `FC` is set to `ifort`
+- `CC` is set to `icc` on Linux and macOS and `icl` on Windows
+- `SETVARS_COMPLETED` indicates whether oneAPI environment variables have been configured (will be `1` if input `setvars` is `true` and variables were successfully configured, otherwise `0`)
+
+**Note:** GitHub Actions does not preserve environment variables between steps by default &mdash; this action persists them via the [`GITHUB_ENV` environment file](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable).
+
 ## Inputs
 
 - `path`
+- `setvars`
 
 ### `path`
 
@@ -45,31 +67,31 @@ The `path` input is the location to install executables. The path may be absolut
 
 The default install location on Linux and Mac is `~/.local/bin/ifort`. The *only* install location currently supported on Windows is `C:\Program Files (x86)\Intel\oneAPI` (see [Windows caveats](#windows-caveats) below).
 
-<!-- ### `version`
+### `setvars`
 
-The `version` input configures the oneAPI toolkit version to install, defaulting to the latest (currently `2022.3`). 
+The `setvars` input is a boolean that controls whether the action runs the oneAPI `setvars` scripts to configure the environment for use. The default is `true`.
 
-**Note:** Intel's website does not maintain a programmatically accessible registry of available versions. Moreover, toolkit versioning is distinct from compiler versioning (see [this page] for a mapping between toolkit and compiler versions). For these reasons a list of permitted version numbers are hard-coded into this action. If a new version has been released and this action has not been updated to support it, please feel free to [file an issue](https://github.com/modflowpy/install-intelfortran-action/issues/new).
+If you prefer to run the oneAPI environment configuration scripts manually, set the `setvars` input to `false`. Then, you can run the `setvars` scripts in a subsequent step.
 
-### `components`
+**Note:** if you elect to activate the oneAPI environment manually, you must either do so in the same step as your compiler invocation, or use the `GITHUB_ENV` environment file to persist the environment variables between steps.
 
-The `components` input allows specifying extra components to install from the HPC kit. -->
+#### Setting oneAPI variables on Linux/macOS
 
-## Environment variables
+On Linux and macOS it is sufficient to source `setvars.sh`, using the `INTEL_HPCKIT_INSTALL_PATH` environment variable to locate it:
 
-The action runs oneAPI configuration scripts (e.g. `setvars.sh`), which set a number of environment variables, the names of which share substring `ONEAPI`.
+```shell
+source "$INTEL_HPCKIT_INSTALL_PATH/setvars.sh"
+```
 
-A few additional variables are also set:
+#### Setting oneAPI variables on Windows
 
-- `INTEL_HPCKIT_INSTALL_PATH` points to the top-level install path
-- `INTEL_HPCKIT_INSTALLER_URL` is the URL of the installer used
-- `INTEL_HPCKIT_COMPONENTS` is a `:`-delimited list of compiler components installed (e.g. `intel.oneapi.win.cpp-compiler:intel.oneapi.win.ifort-compiler` for Windows)
-- `INTEL_COMPILER_BIN_PATH` is the location of compiler executables (this is equivalent to `$HPCKIT_INSTALL_PATH/compilers/latest/<mac, linux, or windows>/bin/intel64`, substituting the proper OS)
-- `INTEL_HPCKIT_VERSION` is the oneAPI HPC toolkit version number used (currently `2022.3`)
-- `FC` is set to `ifort`
-- `CC` is set to `icc` on Linux and macOS and `icl` on Windows
+On Windows, the `vars.bat` script inside the compiler install directory should be used to activate the oneAPI environment. The compiler install directory can be located with the `INTEL_COMPILER_VERSION` variable. For instance, from a `cmd` shell:
 
-**Note:** GitHub Actions does not preserve environment variables between steps by default &mdash; this action persists them via the [`GITHUB_ENV` environment file](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable).
+```cmd
+call "%INTEL_HPCKIT_INSTALL_PATH%\compiler\%INTEL_COMPILER_VERSION%\env\vars.bat"
+```
+
+**Note:** to configure environment variables from PowerShell, it is necessary to reopen a new shell after running scripts (e.g. `... && pwsh`) &mdash; refer to the [Intel documentation](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html) for more info.
 
 ## Windows caveats
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ An action to install and cache the [Intel OneAPI](https://www.intel.com/content/
 - [Environment variables](#environment-variables)
 - [Windows caveats](#windows-caveats)
   - [Bash & MSVC](#bash--msvc)
+  - [Visual Studio](#visual-studio)
   - [Install location](#install-location)
   - [Conda `Scripts`](#conda-scripts)
 - [License](#license)
@@ -77,6 +78,16 @@ There are a few things to be aware of when using this action on Windows runners.
 ### Bash & MSVC
 
 GitHub Actions prepends GNU bin paths to the system path before running `bash` shell steps. This causes the GNU linker to be found even if the MSVC bin directory is on the path (more info [here](https://github.com/ilammy/msvc-dev-cmd#name-conflicts-with-shell-bash)). To make sure the MSVC toolchain is selected in `bash` steps on Windows, this action hides the GNU linker, moving it from `/usr/bin/link` to `$RUNNER_TEMP/link`.
+
+### Visual Studio
+
+GitHub Actions `windows-2022` runner images [have Visual Studio version 17.4](https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#visual-studio-enterprise-2022) preinstalled, however Intel oneAPI compilers are [not yet compatible with Visual Studio 17.4](https://community.intel.com/t5/Intel-C-Compiler/error-no-instance-of-overloaded-function-matches-the-argument/m-p/1436043/highlight/true#M40535). This can cause compiler errors, for instance:
+
+```shell
+error: no instance of overloaded function <function> matches the argument list
+```
+
+To work around this until Intel introduces support for VS 17.4+ it is recommended to use the `windows-2019` runner image, which has Visual Studio 16.
 
 ### Install location
 

--- a/action.yml
+++ b/action.yml
@@ -134,24 +134,30 @@ runs:
         echo "CC=icc" >> $GITHUB_ENV
         echo "ONEAPI_ROOT=$INTEL_HPCKIT_INSTALL_PATH" >> $GITHUB_ENV
 
-    - name: Configure system path (Windows)
+    - name: Check compiler version (Windows)
       if: runner.os == 'Windows'
       shell: cmd
       run: |
         for /f "tokens=* usebackq" %%f in (`dir /b "%INTEL_HPCKIT_INSTALL_PATH%\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST=%%f"
-        set bindir=%INTEL_HPCKIT_INSTALL_PATH%\compiler\%LATEST%\windows\bin\intel64
-        echo adding ifort compiler bin dir '%bindir%' to path
+        echo INTEL_COMPILER_VERSION=%LATEST%>>"$GITHUB_ENV"
+
+    - name: Configure system path (Windows)
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        set bindir=%INTEL_HPCKIT_INSTALL_PATH%\compiler\%INTEL_COMPILER_VERSION%\windows\bin\intel64
+        echo adding compiler bin dir '%bindir%' to path
         echo %bindir%>>"%GITHUB_PATH%"
         echo INTEL_COMPILER_BIN_PATH=%bindir%>>"%GITHUB_ENV%"
 
-    - name: Configure oneAPI environment
+    - name: Configure environment
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        echo "configuring oneAPI environment"
+        echo "configuring environment"
         source "$INTEL_HPCKIT_INSTALL_PATH/setvars.sh"
         
-        echo "persisting oneAPI environment"
+        echo "persisting environment"
         env | grep oneapi >> $GITHUB_ENV
 
     # GitHub Actions prepends GNU linker to the PATH before all bash steps, hide it so MSVC linker is found
@@ -160,22 +166,23 @@ runs:
       shell: bash
       run: mv "/usr/bin/link" "$RUNNER_TEMP/link"
 
-    - name: Prepare MSVC
-      if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
+    # - name: Prepare MSVC
+    #   if: runner.os == 'Windows'
+    #   uses: ilammy/msvc-dev-cmd@v1
 
-    - name: Configure oneAPI environment
+    - name: Configure environment
       if: runner.os == 'Windows'
       shell: cmd
       run: |
-        echo configuring oneAPI environment
+        echo configuring environment
         echo FC=ifort>>"%GITHUB_ENV%"
         echo CC=icl>>"%GITHUB_ENV%"
         echo ONEAPI_ROOT=%INTEL_HPCKIT_INSTALL_PATH%>>"%GITHUB_ENV%"
+        
         call "%INTEL_HPCKIT_INSTALL_PATH%\setvars-vcvarsall.bat"
         for /f "tokens=* usebackq" %%f in (`dir /b "%INTEL_HPCKIT_INSTALL_PATH%\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST=%%f"
         :: this script fails when install location is not the default
         call "%INTEL_HPCKIT_INSTALL_PATH%\compiler\%LATEST%\env\vars.bat"
-    
-        echo persisting oneAPI environment
+        
+        echo persisting environment
         set | findstr /c:"oneAPI" >> "%GITHUB_ENV%"

--- a/action.yml
+++ b/action.yml
@@ -5,13 +5,10 @@ inputs:
     description: Install location
     required: false
     default: ~/.local/bin/ifort
-  # version:
-  #   description: Version of the intel oneAPI HPC toolkit to install
-  #   required: false
-  #   default: "2022.3"
-  # components:
-  #   description: Extra HPC toolkit components to install
-  #   required: false
+  setvars:
+    description: Whether to run scripts to configure oneAPI environment variables
+    required: false
+    default: 'true'
 outputs:
   cache-hit:
     description: Whether the installation was restored from cache
@@ -107,6 +104,20 @@ runs:
         path: ${{ env.INTEL_HPCKIT_INSTALL_PATH }}
         key: intelfortran-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}
 
+    - name: Check compiler version
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        latest=$(ls "$INTEL_HPCKIT_INSTALL_PATH/compiler" | tail -n +2 | sort -V | tail -n 1) 
+        echo "INTEL_COMPILER_VERSION=$latest" >> $GITHUB_ENV
+
+    - name: Check compiler version (Windows)
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        for /f "tokens=* usebackq" %%f in (`dir /b "%INTEL_HPCKIT_INSTALL_PATH%\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST=%%f"
+        echo INTEL_COMPILER_VERSION=%LATEST%>>"%GITHUB_ENV%"
+
     - name: Configure system path
       if: runner.os != 'Windows'
       shell: bash
@@ -130,16 +141,6 @@ runs:
         echo "adding ifort compiler bin dir '$bindir' to path"
         echo "$bindir" >> $GITHUB_PATH
         echo "INTEL_COMPILER_BIN_PATH=$bindir" >> $GITHUB_ENV
-        echo "FC=ifort" >> $GITHUB_ENV
-        echo "CC=icc" >> $GITHUB_ENV
-        echo "ONEAPI_ROOT=$INTEL_HPCKIT_INSTALL_PATH" >> $GITHUB_ENV
-
-    - name: Check compiler version (Windows)
-      if: runner.os == 'Windows'
-      shell: cmd
-      run: |
-        for /f "tokens=* usebackq" %%f in (`dir /b "%INTEL_HPCKIT_INSTALL_PATH%\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST=%%f"
-        echo INTEL_COMPILER_VERSION=%LATEST%>>"$GITHUB_ENV"
 
     - name: Configure system path (Windows)
       if: runner.os == 'Windows'
@@ -150,35 +151,69 @@ runs:
         echo %bindir%>>"%GITHUB_PATH%"
         echo INTEL_COMPILER_BIN_PATH=%bindir%>>"%GITHUB_ENV%"
 
-    - name: Configure environment
+    - name: Set environment variables
       if: runner.os != 'Windows'
       shell: bash
       run: |
-        echo "configuring environment"
+        echo "FC=ifort" >> $GITHUB_ENV
+        echo "CC=icc" >> $GITHUB_ENV
+        echo "ONEAPI_ROOT=$INTEL_HPCKIT_INSTALL_PATH" >> $GITHUB_ENV
+
+    - name: Set environment variables (Windows)
+      if: runner.os == 'Windows'
+      shell: cmd
+      run: |
+        echo FC=ifort>>"%GITHUB_ENV%"
+        echo CC=icl>>"%GITHUB_ENV%"
+        echo ONEAPI_ROOT=%INTEL_HPCKIT_INSTALL_PATH%>>"%GITHUB_ENV%"
+
+    - name: Run setvars scripts
+      if: runner.os != 'Windows' && inputs.setvars == 'true'
+      shell: bash
+      run: |
         source "$INTEL_HPCKIT_INSTALL_PATH/setvars.sh"
-        
-        echo "persisting environment"
         env | grep oneapi >> $GITHUB_ENV
 
+    # - name: Setup MSBuild
+    #   if: runner.os == 'Windows'
+    #   uses: microsoft/setup-msbuild@v1.1
+
+    # - name: Find VS versions
+    #   id: find-vcvars
+    #   if: runner.os == 'Windows'
+    #   shell: pwsh
+    #   run: |
+    #     $products = 'Community','Professional','Enterprise','BuildTools' | %{ "Microsoft.VisualStudio.Product.$_" }
+    #     $vswhere = Get-Command 'vswhere'
+    #     $vs = & $vswhere.Path -products $products -latest -format json | ConvertFrom-Json
+    #     $script = Join-Path $vs.installationPath 'BuildTools' 'VC' 'Auxiliary' 'Build' 'vcvars64.bat'
+    #     echo "vcvars_script=$script" >> $GITHUB_OUTPUT
+
+    # - name: Run vcvars script (Windows)
+    #   if: runner.os == 'Windows'
+    #   shell: cmd
+    #   run: |
+    #     call ${{ steps.find-vcvars.outputs.vcvars_script }}
+    #     :: call "%INTEL_HPCKIT_INSTALL_PATH%\setvars-vcvarsall.bat"
+
+    - name: Run setvars script (Windows)
+      if: runner.os == 'Windows' && inputs.setvars == 'true'
+      shell: cmd
+      run: |
+        for /f "tokens=* usebackq" %%f in (`dir /b "%INTEL_HPCKIT_INSTALL_PATH%\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST=%%f"
+        :: this script fails when install location is not the default
+        call "%INTEL_HPCKIT_INSTALL_PATH%\compiler\%LATEST%\env\vars.bat"
+        set | findstr /c:"oneAPI" >> "%GITHUB_ENV%"
+
+    - name: Set SETVARS_COMPLETED
+      if: inputs.setvars == 'true'
+      shell: bash
+      run: echo "SETVARS_COMPLETED=1" >> $GITHUB_ENV
+
     # GitHub Actions prepends GNU linker to the PATH before all bash steps, hide it so MSVC linker is found
-    - name: Hide GNU linker
+    - name: Hide GNU linker (Windows)
       if: runner.os == 'Windows'
       shell: bash
       run: mv "/usr/bin/link" "$RUNNER_TEMP/link"
 
-    - name: Configure environment
-      if: runner.os == 'Windows'
-      shell: cmd
-      run: |
-        echo configuring environment
-        echo FC=ifort>>"%GITHUB_ENV%"
-        echo CC=icl>>"%GITHUB_ENV%"
-        echo ONEAPI_ROOT=%INTEL_HPCKIT_INSTALL_PATH%>>"%GITHUB_ENV%"
-        
-        call "%INTEL_HPCKIT_INSTALL_PATH%\setvars-vcvarsall.bat"
-        for /f "tokens=* usebackq" %%f in (`dir /b "%INTEL_HPCKIT_INSTALL_PATH%\compiler\" ^| findstr /V latest ^| sort`) do @set "LATEST=%%f"
-        :: this script fails when install location is not the default
-        call "%INTEL_HPCKIT_INSTALL_PATH%\compiler\%LATEST%\env\vars.bat"
-        
-        echo persisting environment
-        set | findstr /c:"oneAPI" >> "%GITHUB_ENV%"
+

--- a/action.yml
+++ b/action.yml
@@ -166,10 +166,6 @@ runs:
       shell: bash
       run: mv "/usr/bin/link" "$RUNNER_TEMP/link"
 
-    # - name: Prepare MSVC
-    #   if: runner.os == 'Windows'
-    #   uses: ilammy/msvc-dev-cmd@v1
-
     - name: Configure environment
       if: runner.os == 'Windows'
       shell: cmd


### PR DESCRIPTION
- Removes the `ilammy/msvc-dev-cmd` step. This was unnecessary since the GNU linker is now hidden on Windows as of #17. It could also cause [path length errors](https://community.intel.com/t5/Intel-Fortran-Compiler/Input-line-too-long-error-when-running-Windows-batch-file/m-p/1138556) since it calls a Visual Studio `vcvarsall.bat` script after environment variables have already been configured by Intel oneAPI scripts, in some cases exceeding the maximum length allowed for `PATH`.

- Introduces an input `setvars`, defaulting to `true`, to toggle whether the action should run scripts to set oneAPI environment variables. If the user plans to do so manually this can be set to `false` (e.g., for `pymake`, which runs the scripts internally). This can help avoid path length errors on Windows.

- Sets environment variable `SETVARS_COMPLETED` as per [Intel convention](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html) to indicate `setvars` scripts have run.

- Adds a caveat to `README.md` recommending `windows-2019` runners until [oneAPI compilers support Visual Studio 17.4](https://community.intel.com/t5/Intel-C-Compiler/error-no-instance-of-overloaded-function-matches-the-argument/m-p/1436043/highlight/true#M40535), which is the VS version [currently installed on `windows-2022` runners](https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md#visual-studio-enterprise-2022).

- Introduces integration tests for [`pymake`](https://github.com/modflowpy/pymake).