### PR TITLE
fix(caching): rotate cache key, make caching optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ An action to install and cache [Intel OneAPI](https://www.intel.com/content/www/
   - [`setvars`](#setvars)
     - [Setting oneAPI variables on Linux/macOS](#setting-oneapi-variables-on-linuxmacos)
     - [Setting oneAPI variables on Windows](#setting-oneapi-variables-on-windows)
+  - [`cache`](#cache)
 - [Windows caveats](#windows-caveats)
   - [Bash & MSVC](#bash--msvc)
   - [Visual Studio](#visual-studio)
@@ -60,6 +61,7 @@ Besides oneAPI environment variables configured by `setvars` scripts (whose name
 
 - `path`
 - `setvars`
+- `cache`
 
 ### `path`
 
@@ -92,6 +94,12 @@ call "%INTEL_HPCKIT_INSTALL_PATH%\compiler\%INTEL_COMPILER_VERSION%\env\vars.bat
 ```
 
 **Note:** to configure environment variables from PowerShell, it is necessary to reopen a new shell after running scripts (e.g. `... && pwsh`) &mdash; refer to the [Intel documentation](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html) for more info.
+
+### `cache`
+
+The `cache` input is a boolean that controls whether the action caches the oneAPI compiler installation. The default is `true`.
+
+**Note:** installation on Windows can take a long time (~30 minutes) so caching is recommended, however an [outstanding cache reservation bug in `actions/cache`](https://github.com/actions/cache/issues/144) can cause the cache to [fail to restore while simultaneously rejecting new saves](https://github.com/MODFLOW-USGS/modflow6/actions/runs/3624583228/jobs/6111766806#step:6:152). The [GitHub-endorsed workaround for this issue](https://github.com/actions/cache/issues/144#issuecomment-579323937) is currently to change keys, therefore this action rotates the cache key once daily.
 
 ## Windows caveats
 

--- a/action.yml
+++ b/action.yml
@@ -69,12 +69,17 @@ runs:
       shell: bash
       run: mv "C:\Program Files\Git\usr\bin\tar.exe" "$RUNNER_TEMP\tar.exe"
 
+    - name: Get Date
+      id: get-date
+      shell: bash
+      run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
+
     - name: Restore cache
       id: cache-ifort
       uses: martijnhols/actions-cache/restore@v3
       with:
         path: ${{ env.INTEL_HPCKIT_INSTALL_PATH }}
-        key: intelfortran-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}
+        key: intelfortran-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}-${{ steps.get-date.outputs.date }}
 
     # restore GNU tar
     - name: Restore GNU tar
@@ -102,7 +107,7 @@ runs:
       uses: martijnhols/actions-cache/save@v3
       with:
         path: ${{ env.INTEL_HPCKIT_INSTALL_PATH }}
-        key: intelfortran-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}
+        key: intelfortran-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}-${{ steps.get-date.outputs.date }}
 
     - name: Check compiler version
       if: runner.os != 'Windows'

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: Whether to run scripts to configure oneAPI environment variables
     required: false
     default: 'true'
+  cache:
+    description: Whether to cache the installation
+    required: false
+    default: 'true'
 outputs:
   cache-hit:
     description: Whether the installation was restored from cache
@@ -65,16 +69,18 @@ runs:
 
     # GNU tar can't handle symlinks on Windows, hide it so default Windows tar is used to restore cache
     - name: Hide GNU tar
-      if: runner.os == 'windows'
+      if: runner.os == 'windows' && inputs.cache == 'true'
       shell: bash
       run: mv "C:\Program Files\Git\usr\bin\tar.exe" "$RUNNER_TEMP\tar.exe"
 
     - name: Get Date
+      if: inputs.cache == 'true'
       id: get-date
       shell: bash
       run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
 
     - name: Restore cache
+      if: inputs.cache == 'true'
       id: cache-ifort
       uses: martijnhols/actions-cache/restore@v3
       with:
@@ -83,7 +89,7 @@ runs:
 
     # restore GNU tar
     - name: Restore GNU tar
-      if: runner.os == 'windows'
+      if: runner.os == 'windows' && inputs.cache == 'true'
       shell: bash
       run: mv "$RUNNER_TEMP\tar.exe" 'C:\Program Files\Git\usr\bin\tar.exe'
 
@@ -103,7 +109,7 @@ runs:
         call "%GITHUB_ACTION_PATH%\scripts\install_windows.bat" "${{ env.INTEL_HPCKIT_INSTALL_PATH }}" "${{ env.INTEL_HPCKIT_INSTALLER_URL }}" "${{ env.INTEL_HPCKIT_COMPONENTS }}"
 
     - name: Save cache
-      if: steps.cache-ifort.outputs.cache-hit != 'true'
+      if: inputs.cache == 'true' && steps.cache-ifort.outputs.cache-hit != 'true'
       uses: martijnhols/actions-cache/save@v3
       with:
         path: ${{ env.INTEL_HPCKIT_INSTALL_PATH }}


### PR DESCRIPTION
Due to a [long-outstanding `actions/cache` bug](https://github.com/actions/cache/issues/144), the cache can get into a bad state where it will [fail to restore existing entries while rejecting new attempts to save](https://github.com/MODFLOW-USGS/modflow6/actions/runs/3624583228/jobs/6111766806#step:6:152). The [recommended workaround](https://github.com/actions/cache/issues/144#issuecomment-579323937) is to change the cache key. This PR rotates the cache key once daily and also makes caching optional via the `cache` input.