### PR TITLE
refactor: use actions/cache save and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub tag](https://img.shields.io/github/tag/modflowpy/install-intelfortran-action.svg)](https://github.com/modflowpy/install-intelfortran-action/tags/latest)
 [![CI](https://github.com/modflowpy/install-intelfortran-action/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/modflowpy/install-intelfortran-action/actions/workflows/ci.yml)
-[![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
+[![Project Status: Inactive – The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](https://www.repostatus.org/badges/latest/inactive.svg)](https://www.repostatus.org/#inactive)
 
 An action to install and cache [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran and C/C++ compilers via the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy).
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,13 @@ outputs:
 runs:
   using: composite
   steps:
+
+    - name: Deprecation warning
+      shell: bash
+      run: |
+        echo "WARNING: This action will be archived on 01/01/24 in light of better alternatives."
+        echo "Please use awvwgk/setup-fortran instead (https://github.com/awvwgk/setup-fortran)."
+
     - name: Set install path
       if: runner.os != 'Windows'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
     - name: Restore cache
       if: inputs.cache == 'true'
       id: cache-ifort
-      uses: martijnhols/actions-cache/restore@v3
+      uses: actions/cache/restore@v3
       with:
         path: ${{ env.INTEL_HPCKIT_INSTALL_PATH }}
         key: intelfortran-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}-${{ steps.get-date.outputs.date }}
@@ -117,7 +117,7 @@ runs:
 
     - name: Save cache
       if: inputs.cache == 'true' && steps.cache-ifort.outputs.cache-hit != 'true'
-      uses: martijnhols/actions-cache/save@v3
+      uses: actions/cache/save@v3
       with:
         path: ${{ env.INTEL_HPCKIT_INSTALL_PATH }}
         key: intelfortran-${{ runner.os }}-${{ env.INTEL_HPCKIT_VERSION }}-${{ env.INTEL_HPCKIT_COMPONENTS }}-${{ steps.get-date.outputs.date }}


### PR DESCRIPTION
- `actions/cache` now offers [more granular control](https://github.com/actions/cache#cache-action) over save/restore operations
- add retirement warning / suggestion to migrate to [`awvwgk/setup-fortran`](https://github.com/awvwgk/setup-fortran)