### PR TITLE
docs(readme): suggest migration, update ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, macos-11, macos-12, windows-2019, windows-2022 ]
         path: [ absolute, relative, tilde, default ]
         setvars: [ 'true', 'false' ]
     steps:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 An action to install and cache [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran and C/C++ compilers via the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy).
 
+**Note:** [`awvwgk/setup-fortran`](https://github.com/awvwgk/setup-fortran) is recommended. Maintenance of this action will cease in 2024.
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 


### PR DESCRIPTION
- warn of impending retirement, suggestion switching to `awvwgk/setup-fortran`
- remove `ubuntu-18` from test matrix ([deprecated](https://github.com/actions/runner-images/issues/6002))