### PR TITLE
remove migration brownout, update README re: cessation of support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 [![GitHub tag](https://img.shields.io/github/tag/modflowpy/install-intelfortran-action.svg)](https://github.com/modflowpy/install-intelfortran-action/tags/latest)
 [![CI](https://github.com/modflowpy/install-intelfortran-action/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/modflowpy/install-intelfortran-action/actions/workflows/ci.yml)
-[![Project Status: Inactive – The project has reached a stable, usable state but is no longer being actively developed; support/maintenance will be provided as time allows.](https://www.repostatus.org/badges/latest/inactive.svg)](https://www.repostatus.org/#inactive)
+[![Project Status: Unsupported – The project has reached a stable, usable state but the author(s) have ceased all work on it. A new maintainer may be desired.](https://www.repostatus.org/badges/latest/unsupported.svg)](https://www.repostatus.org/#unsupported)
 
 An action to install and cache [Intel OneAPI](https://www.intel.com/content/www/us/en/developer/tools/oneapi/fortran-compiler.html#gs.bksc2p) Fortran and C/C++ compilers via the [HPC Toolkit](https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit.html#gs.g10hgy).
 
-**Note:** Maintenance of this action will cease in 2024. [`fortran-lang/setup-fortran`](https://github.com/fortran-lang/setup-fortran) is recommended instead. This action will disable itself 10% of the time until then (to avoid this, use a previous tag).
+**Note:** Maintenance of this action has ceased. [`fortran-lang/setup-fortran`](https://github.com/fortran-lang/setup-fortran) is recommended instead.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/action.yml
+++ b/action.yml
@@ -24,14 +24,8 @@ runs:
     - name: Migration warning
       shell: bash
       run: |
-        echo "WARNING: This action will be archived on 01/01/24."
+        echo "WARNING: This action is unsupported."
         echo "Use fortran-lang/setup-fortran instead (https://github.com/fortran-lang/setup-fortran)."
-
-    - name: Migration brownout
-      uses: wpbonelli/schedule-outage@v1
-      with:
-        probability: 0.1
-        message: "This action will be archived on 01/01/24. Use fortran-lang/setup-fortran instead (https://github.com/fortran-lang/setup-fortran)."
 
     - name: Set install path
       if: runner.os != 'Windows'


### PR DESCRIPTION
* remove 10% random chance of failure (migration warning brownout)
* mention support has ceased in README and update status badge